### PR TITLE
Changed 'stat' json key from 'mime-type' to 'content-type'

### DIFF
--- a/services/Donkey/src/donkey/services/filesystem/stat.clj
+++ b/services/Donkey/src/donkey/services/filesystem/stat.clj
@@ -55,7 +55,7 @@
   (if-not (is-dir? cm path)
     (-> stat-map
       (merge {:info-type (filetypes/get-types cm user path)})
-      (merge {:mime-type (detect-content-type cm path)}))
+      (merge {:content-type (detect-content-type cm path)}))
     stat-map))
 
 (defn path-is-dir?


### PR DESCRIPTION
This is for two reasons. The first is for consistency with the keys from
the 'manifest' endpoint. The other is that this key matches the name of
the HTTP header field definition;
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html sec 14.17.
