### PR TITLE
CORE-6950: metadata: can't create metadata templates with non-required attribute

### DIFF
--- a/databases/metadata/src/main/conversions/c210_2015080701.clj
+++ b/databases/metadata/src/main/conversions/c210_2015080701.clj
@@ -1,0 +1,11 @@
+(ns facepalm.c210-2015080701
+  (:use [korma.core]))
+
+(def ^:private version
+  "The destination database version."
+  "2.1.0:20150807.01")
+
+(defn convert
+  []
+  (println "Performing the conversion for" version)
+  (exec-raw "ALTER TABLE attributes ALTER COLUMN required SET DEFAULT FALSE"))

--- a/databases/metadata/src/main/data/99_version.sql
+++ b/databases/metadata/src/main/data/99_version.sql
@@ -5,3 +5,4 @@ INSERT INTO version (version) VALUES ('1.8.9:20140707.01');
 INSERT INTO version (version) VALUES ('1.9.2:20140902.01');
 INSERT INTO version (version) VALUES ('2.0.0:20150529.01');
 INSERT INTO version (version) VALUES ('2.0.0:20150601.01');
+INSERT INTO version (version) VALUES ('2.1.0:20150807.01');

--- a/databases/metadata/src/main/tables/attributes.sql
+++ b/databases/metadata/src/main/tables/attributes.sql
@@ -7,7 +7,7 @@ CREATE TABLE attributes (
     id uuid NOT NULL DEFAULT uuid_generate_v1(),
     name varchar(64) NOT NULL,
     description text NOT NULL,
-    required boolean NOT NULL,
+    required boolean NOT NULL DEFAULT FALSE,
     value_type_id uuid NOT NULL,
     created_by uuid NOT NULL,
     modified_by uuid NOT NULL,

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -13,7 +13,7 @@
                  [postgresql "9.1-901-1.jdbc4"]
                  [slingshot "0.10.3"]]
   :plugins [[lein-marginalia "0.7.1"]]
-  :manifest {"db-version" "2.0.0:20150724.01"}
+  :manifest {"db-version" "2.1.0:20150807.01"}
   :repositories [["sonatype-nexus-snapshots"
                   {:url "https://oss.sonatype.org/content/repositories/snapshots"}]]
   :deploy-repositories [["sonatype-nexus-staging"

--- a/services/metadata/src/metadata/routes/domain/template.clj
+++ b/services/metadata/src/metadata/routes/domain/template.clj
@@ -82,7 +82,7 @@
    :name
    (describe String "The attribute name")
 
-   :required
+   (s/optional-key :required)
    (describe Boolean "True if the attribute must have a value")
 
    :type


### PR DESCRIPTION
Set attribute 'required' property default false at the database level, and optional at the swagger schema level.