### PR TITLE
CORE-6974: list of value types is not used for schema validation/in swagger UI

### DIFF
--- a/services/metadata/src/metadata/core.clj
+++ b/services/metadata/src/metadata/core.clj
@@ -27,9 +27,8 @@
 (defn -main
   [& args]
   (tc/set-context! config/svc-info)
-  (require 'metadata.routes)
-  (let [app (eval 'metadata.routes/app)
-        {:keys [options arguments errors summary]} (ccli/handle-args config/svc-info args cli-options)]
+  (let [{:keys [options arguments errors summary]} (ccli/handle-args config/svc-info args cli-options)]
     (init-service (:config options))
     (log/warn "Started listening on" (config/listen-port))
-    (jetty/run-jetty app {:port (config/listen-port)})))
+    (require 'metadata.routes) ; After init-service so the database is initialized
+    (jetty/run-jetty (eval 'metadata.routes/app) {:port (config/listen-port)})))

--- a/services/metadata/src/metadata/persistence/templates.clj
+++ b/services/metadata/src/metadata/persistence/templates.clj
@@ -117,6 +117,10 @@
                                    :attribute_id  attr-id
                                    :display_order order})))
 
+(defn get-value-type-names
+  []
+  (map #(:name %) (select :value_types (fields :name))))
+
 (defn- get-value-type-id
   [type-name]
   (:id (first (select :value_types (where {:name type-name})))))

--- a/services/metadata/src/metadata/routes/domain/template.clj
+++ b/services/metadata/src/metadata/routes/domain/template.clj
@@ -1,10 +1,12 @@
 (ns metadata.routes.domain.template
-  (:use [compojure.api.sweet :only [describe]])
+  (:use [compojure.api.sweet :only [describe]]
+        [korma.core])
   (:require [schema.core :as s])
   (:import [java.util Date UUID]))
 
 (def TemplateIdPathParam (describe UUID "The metadata template ID"))
 (def AttrIdPathParam (describe UUID "The metadata attribute ID"))
+(def ValidValueTypeEnum (apply s/enum (map #(:name %) (select :value_types (fields :name)))))
 
 (s/defschema MetadataTemplateListEntry
   {:created_by  (describe UUID "The ID of the user who created the template")
@@ -52,7 +54,7 @@
    (describe Boolean "True if the attribute must have a value")
 
    :type
-   (describe String "The attribute data type")
+   (describe ValidValueTypeEnum "The attribute data type")
 
    (s/optional-key :values)
    (describe [TemplateAttrEnumValue] "The list of possible values for enumeration types")})
@@ -86,7 +88,7 @@
    (describe Boolean "True if the attribute must have a value")
 
    :type
-   (describe String "The attribute data type")
+   (describe ValidValueTypeEnum "The attribute data type")
 
    (s/optional-key :values)
    (describe [TemplateAttrEnumValueUpdate] "The list of possible values for enumeration types")})

--- a/services/metadata/src/metadata/routes/domain/template.clj
+++ b/services/metadata/src/metadata/routes/domain/template.clj
@@ -1,12 +1,12 @@
 (ns metadata.routes.domain.template
-  (:use [compojure.api.sweet :only [describe]]
-        [korma.core])
-  (:require [schema.core :as s])
+  (:use [compojure.api.sweet :only [describe]])
+  (:require [schema.core :as s]
+            [metadata.persistence.templates :as tp])
   (:import [java.util Date UUID]))
 
 (def TemplateIdPathParam (describe UUID "The metadata template ID"))
 (def AttrIdPathParam (describe UUID "The metadata attribute ID"))
-(def ValidValueTypeEnum (apply s/enum (map #(:name %) (select :value_types (fields :name)))))
+(def ValidValueTypeEnum (describe (apply s/enum (tp/get-value-type-names)) "The attribute's data type"))
 
 (s/defschema MetadataTemplateListEntry
   {:created_by  (describe UUID "The ID of the user who created the template")
@@ -54,7 +54,7 @@
    (describe Boolean "True if the attribute must have a value")
 
    :type
-   (describe ValidValueTypeEnum "The attribute data type")
+   ValidValueTypeEnum
 
    (s/optional-key :values)
    (describe [TemplateAttrEnumValue] "The list of possible values for enumeration types")})
@@ -88,7 +88,7 @@
    (describe Boolean "True if the attribute must have a value")
 
    :type
-   (describe ValidValueTypeEnum "The attribute data type")
+   ValidValueTypeEnum
 
    (s/optional-key :values)
    (describe [TemplateAttrEnumValueUpdate] "The list of possible values for enumeration types")})


### PR DESCRIPTION
Loads an enumeration of valid value-types from the DB on startup of the metadata service, for better swagger interface/error messages.