### PR TITLE
CORE-6953: clean up null-named root app categories and workspaces that use them

### DIFF
--- a/databases/de-database-schema/src/main/conversions/c210_2015081201.clj
+++ b/databases/de-database-schema/src/main/conversions/c210_2015081201.clj
@@ -1,0 +1,40 @@
+(ns facepalm.c210-2015081201
+  (:use [korma.core]
+        [facepalm.error-codes :only [conversion-validation-error]]))
+
+(def ^:private version
+  "The destination database version."
+  "2.1.0:20150812.01")
+
+(defn convert
+  []
+  (println "Performing the conversion for" version)
+  ;; collect offending app_categories IDs
+  (let [bad-categories (map :id (select :app_categories (fields [:id]) (where (= :name nil))))
+        bad-workspaces (map :id (select :workspace (fields [:id]) (where {:root_category_id [in bad-categories]})))]
+    ;; delete app_category_group rows where offending categories are children
+    (delete :app_category_group (where {:child_category_id [in bad-categories]}))
+    ;; VERIFY: no suggested_groups, app_category_app, or app_category_group rows referencing offending categories
+    (let [bad-suggestions (map :app_category_id (select :suggested_groups (fields [:app_category_id]) (where {:app_category_id [in bad-categories]})))
+          bad-apps (map :app_category_id (select :app_category_app (fields [:app_category_id]) (where {:app_category_id [in bad-categories]})))
+          bad-groups (map :parent_category_id (select :app_category_group (fields [:parent_category_id]) (where {:parent_category_id [in bad-categories]})))]
+      (if (> 0 (+ (count bad-suggestions) (count bad-apps) (count bad-groups)))
+        (conversion-validation-error version
+                                     {:error-code  :extra-groups-apps-suggestions-null-names})))
+    ;; update (to null) workspaces' root_category_ids of offending workspaces, collect workspace IDs
+    (update :workspace (set-fields {:root_category_id nil}) (where {:id [in bad-workspaces]}))
+    ;; delete offending app categories
+    (delete :app_categories (where (= :name nil)))
+    ;; VERIFY: no app categories reference problem workspaces
+    (let [bad-extra-categories (map :id (select :app_categories (fields [:id]) (where {:workspace_id [in bad-workspaces]})))]
+      (if (> 0 (count bad-extra-categories))
+        (conversion-validation-error version
+                                     {:error-code :extra-categories-reference-bad-workspaces})))
+    ;; delete workspaces
+    (delete :workspace (where {:id [in bad-workspaces]})))
+  ;; VERIFY: no remaining problems
+  (let [bad-categories (map :id (select :app_categories (fields [:id]) (where (= :name nil))))]
+    (if (> 0 (count bad-categories))
+      (conversion-validation-error version {:error-code :not-all-categories-cleaned})))
+  ;; add not-null constraint
+  (exec-raw "ALTER TABLE app_categories ALTER COLUMN name SET NOT NULL"))

--- a/databases/de-database-schema/src/main/data/99_version.sql
+++ b/databases/de-database-schema/src/main/data/99_version.sql
@@ -62,3 +62,4 @@ INSERT INTO version (version) VALUES ('1.9.7:20150209.01');
 INSERT INTO version (version) VALUES ('1.9.9:20150530.05');
 INSERT INTO version (version) VALUES ('2.0.0:20150602.01');
 INSERT INTO version (version) VALUES ('2.0.0:20150630.01');
+INSERT INTO version (version) VALUES ('2.1.0:20150812.01');

--- a/libs/kameleon/project.clj
+++ b/libs/kameleon/project.clj
@@ -11,7 +11,7 @@
                  [postgresql "9.1-901-1.jdbc4"]
                  [slingshot "0.10.3"]]
   :plugins [[lein-marginalia "0.7.1"]]
-  :manifest {"db-version" "2.1.0:20150811.01"}
+  :manifest {"db-version" "2.1.0:20150812.01"}
   :repositories [["sonatype-nexus-snapshots"
                   {:url "https://oss.sonatype.org/content/repositories/snapshots"}]]
   :deploy-repositories [["sonatype-nexus-staging"

--- a/services/metadactyl-clj/src/metadactyl/persistence/workspace.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/workspace.clj
@@ -1,5 +1,6 @@
 (ns metadactyl.persistence.workspace
-  (:use [korma.core])
+  (:use [korma.core]
+        [korma.db :only [transaction]])
   (:require [kameleon.app-groups :as app-groups]
             [kameleon.queries :as queries]
             [metadactyl.util.config :as config]))
@@ -31,7 +32,8 @@
 
 (defn create-workspace
   [username]
-  (-> (queries/get-user-id username)
-      (queries/create-workspace)
-      (add-root-app-category)
-      (select-keys [:id :user_id :root_category_id :is_public])))
+  (transaction
+    (-> (queries/get-user-id username)
+        (queries/create-workspace)
+        (add-root-app-category)
+        (select-keys [:id :user_id :root_category_id :is_public]))))


### PR DESCRIPTION
Additionally, wraps the metadactyl endpoint that creates these in a transaction, as mentioned on the ticket.