### PR TITLE
CORE-6975 cleanup

### DIFF
--- a/services/Donkey/src/donkey/clients/metadata.clj
+++ b/services/Donkey/src/donkey/clients/metadata.clj
@@ -24,13 +24,13 @@
   (parse-body (raw/admin-list-templates)))
 
 (defn admin-add-template
-  [user-id template]
-  (parse-body (raw/admin-add-template user-id (cheshire/encode template))))
+  [template]
+  (parse-body (raw/admin-add-template (cheshire/encode template))))
 
 (defn admin-update-template
-  [user-id template-id template]
-  (parse-body (raw/admin-update-template user-id template-id (cheshire/encode template))))
+  [template-id template]
+  (parse-body (raw/admin-update-template template-id (cheshire/encode template))))
 
 (defn admin-delete-template
-  [user-id template-id]
-  (raw/admin-delete-template user-id template-id))
+  [template-id]
+  (raw/admin-delete-template template-id))

--- a/services/Donkey/src/donkey/clients/metadata/raw.clj
+++ b/services/Donkey/src/donkey/clients/metadata/raw.clj
@@ -174,14 +174,14 @@
   (http/get (metadata-url "admin" "templates") (get-options)))
 
 (defn admin-add-template
-  [user-id template]
-  (http/post (metadata-url "admin" "templates") (post-options template {:user-id user-id})))
+  [template]
+  (http/post (metadata-url "admin" "templates") (post-options template)))
 
 (defn admin-update-template
-  [user-id template-id template]
+  [template-id template]
   (http/put (metadata-url "admin" "templates" template-id)
-            (put-options template {:user-id user-id})))
+            (put-options template)))
 
 (defn admin-delete-template
-  [user-id template-id]
-  (http/delete (metadata-url "admin" "templates" template-id) (delete-options {:user-id user-id})))
+  [template-id]
+  (http/delete (metadata-url "admin" "templates" template-id) (delete-options)))

--- a/services/metadata/src/metadata/routes/domain/common.clj
+++ b/services/metadata/src/metadata/routes/domain/common.clj
@@ -19,10 +19,6 @@
 (s/defschema StandardQueryParams
   {:user (describe NonBlankString "The username of the authenticated user")})
 
-(s/defschema UserIdParams
-  (assoc StandardQueryParams
-    :user-id (describe UUID "The user ID from the app database")))
-
 (s/defschema StandardDataItemQueryParams
   (assoc StandardQueryParams
     :data-type (describe DataTypeEnum "The type of the requested data item.")))

--- a/services/metadata/src/metadata/routes/templates.clj
+++ b/services/metadata/src/metadata/routes/templates.clj
@@ -44,7 +44,7 @@
       (service/trap uri templates/admin-list-templates))
 
     (POST* "/" [:as {:keys [uri]}]
-      :query [params UserIdParams]
+      :query [params StandardQueryParams]
       :body [body (describe MetadataTemplateUpdate "The template to add.")]
       :return MetadataTemplate
       :summary "Add a Metadata Template"
@@ -54,7 +54,7 @@
     (PUT* "/:template-id" [:as {:keys [uri]}]
       :path-params [template-id :- TemplateIdPathParam]
       :body [body (describe MetadataTemplateUpdate "The template to update.")]
-      :query [params UserIdParams]
+      :query [params StandardQueryParams]
       :return MetadataTemplate
       :summary "Update a Metadata Template"
       :description "This endpoint allows administrators to update existing metadata templates."
@@ -62,7 +62,7 @@
 
     (DELETE* "/:template-id" [:as {:keys [uri]}]
       :path-params [template-id :- TemplateIdPathParam]
-      :query [params UserIdParams]
+      :query [params StandardQueryParams]
       :summary "Mark a Metadata Template as Deleted"
       :description "This endpoint allows administrators to mark existing metadata templates as
       deleted."

--- a/services/metadata/src/metadata/services/templates.clj
+++ b/services/metadata/src/metadata/services/templates.clj
@@ -29,13 +29,13 @@
   {:metadata_templates (mapv remove-nil-values (tp/list-templates false))})
 
 (defn add-template
-  [{:keys [user-id]} template]
-  (transaction (view-template (tp/add-template user-id template))))
+  [{:keys [user]} template]
+  (transaction (view-template (tp/add-template user template))))
 
 (defn update-template
-  [{:keys [user-id]} template-id template]
-  (transaction (view-template (tp/update-template user-id template-id template))))
+  [{:keys [user]} template-id template]
+  (transaction (view-template (tp/update-template user template-id template))))
 
 (defn delete-template
-  [{:keys [user-id]} template-id]
-  (transaction (tp/delete-template user-id template-id)))
+  [{:keys [user]} template-id]
+  (transaction (tp/delete-template user template-id)))


### PR DESCRIPTION
Some stuff I missed:
 * Modify Donkey endpoints for not munging around with usernames and IDs
 * Fix params for metadata endpoints to no longer require user IDs

Should this get merged while I'm out tomorrow (hopefully, since I think stuff is broken without it), please set the ticket to Validate and label appropriately for me!