### PR TITLE
CORE-6243: Migrate /secured/filesystem/rename to data-info from Donkey.

### DIFF
--- a/services/Donkey/src/donkey/clients/data_info.clj
+++ b/services/Donkey/src/donkey/clients/data_info.clj
@@ -86,6 +86,13 @@
         :paths
         (get path))))
 
+(defn rename
+  [params body]
+  (let [url (url/url (cfg/data-info-base-url) "data" "rename")
+        req-map {:query-params (select-keys params [:user])
+                 :content-type :json
+                 :body         (json/encode body)}]
+    (http/post (str url) req-map)))
 
 (defn get-or-create-dir
   "Returns the path argument if the path exists and refers to a directory.  If

--- a/services/Donkey/src/donkey/routes/filesystem.clj
+++ b/services/Donkey/src/donkey/routes/filesystem.clj
@@ -21,7 +21,6 @@
             [donkey.services.filesystem.page-csv :as csv]
             [donkey.services.filesystem.page-file :as file]
             [donkey.services.filesystem.preview :as preview]
-            [donkey.services.filesystem.rename :as rename]
             [donkey.services.filesystem.root :as root]
             [donkey.services.filesystem.sharing :as sharing]
             [donkey.services.filesystem.space-handling :as sh]
@@ -67,7 +66,7 @@
       (controller req data/create-dir :params :body))
 
     (POST "/filesystem/rename" [:as req]
-      (controller req rename/do-rename :params :body))
+      (controller req data/rename :params :body))
 
     (POST "/filesystem/delete" [:as req]
       (controller req trash/do-delete :params :body))

--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -4,6 +4,7 @@
         [data-info.routes.domain.data]
         [data-info.routes.domain.stats])
   (:require [data-info.services.create :as create]
+            [data-info.services.rename :as rename]
             [data-info.services.metadata :as meta]
             [data-info.util.service :as svc]))
 
@@ -26,6 +27,17 @@ for the requesting user."
 (get-error-code-block
   "ERR_BAD_OR_MISSING_FIELD, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_DOES_NOT_EXIST, ERR_NOT_A_USER"))
       (svc/trap uri create/do-create params body))
+
+    (POST* "/rename" [:as {uri :uri}]
+      :query [params SecuredQueryParamsRequired]
+      :body [body (describe RenameRequest "The renaming to perform.")]
+      :return RenameResult
+      :summary "Rename Files"
+      :description (str
+"Renames a file given two paths."
+(get-error-code-block
+  "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
+      (svc/trap uri rename/do-rename params body))
 
     (POST* "/:data-id/metadata/save" [:as {uri :uri}]
       :path-params [data-id :- DataIdPathParam]

--- a/services/data-info/src/data_info/routes/domain/data.clj
+++ b/services/data-info/src/data_info/routes/domain/data.clj
@@ -12,3 +12,13 @@
      "When set to true and the given source is a folder, then all files and subfolders (plus all
       their files and subfolders) under the source folder will be included in the exported file,
       along with all of their metadata")})
+
+(s/defschema RenameRequest
+  {:source
+   (describe NonBlankString "An iRODS path to the initial location of the file being renamed.")
+
+   :dest
+   (describe NonBlankString "An iRODS path to the final location of the file being renamed.")})
+
+(s/defschema RenameResult
+  (assoc RenameRequest :user (describe NonBlankString "The user performing the request.")))


### PR DESCRIPTION
For my first data-info migration, I'm assuming review would be a good plan. I'm not quite sure how to go about testing this -- I guess set up data-info locally with de-2, query the endpoint, and confirm with the de-2 interface that it actually renamed, but that won't test the Donkey part, which I'm not sure I can reasonably set up with my (non-)knowledge of CAS.