### PR TITLE
data-info RESTification, the rename endpoint

### DIFF
--- a/services/Donkey/src/donkey/clients/data_info.clj
+++ b/services/Donkey/src/donkey/clients/data_info.clj
@@ -11,6 +11,7 @@
             [clj-icat-direct.icat :as db]
             [clojure-commons.error-codes :as error]
             [clojure-commons.file-utils :as ft]
+            [clojure-commons.assertions :as assertions]
             [donkey.services.filesystem.common-paths :as cp]
             [donkey.services.filesystem.create :as cr]
             [donkey.services.filesystem.exists :as e]
@@ -92,8 +93,8 @@
   "Uses the data-info set-name endpoint to rename a file within the same directory."
   [params body]
   (with-jargon (icat/jargon-cfg) [cm]
-    (if (not= (ft/dirname (:dest body)) (ft/dirname (:source body)))
-      (throw+ {:error_code error/ERR_BAD_OR_MISSING_FIELD}))
+    (assertions/assert-valid (= (ft/dirname (:dest body)) (ft/dirname (:source body)))
+        "The directory names of the source and destination must match for this endpoint.")
     (let [path-uuid (:id (uuids/uuid-for-path cm (:user params) (:source body)))
           url (url/url (cfg/data-info-base-url) "data" path-uuid "name")
           req-map {:query-params (select-keys params [:user])

--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -28,16 +28,17 @@ for the requesting user."
   "ERR_BAD_OR_MISSING_FIELD, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_DOES_NOT_EXIST, ERR_NOT_A_USER"))
       (svc/trap uri create/do-create params body))
 
-    (POST* "/rename" [:as {uri :uri}]
+    (PUT* "/:data-id/name" [:as {uri :uri}]
+      :path-params [data-id :- DataIdPathParam]
       :query [params SecuredQueryParamsRequired]
-      :body [body (describe RenameRequest "The renaming to perform.")]
+      :body [body (describe Filename "The new name of the file.")]
       :return RenameResult
-      :summary "Rename Files"
+      :summary "Change a file's name."
       :description (str
-"Renames a file given two paths."
+"Moves the file with the provided UUID to a new name within the same folder."
 (get-error-code-block
   "ERR_NOT_A_FOLDER, ERR_DOES_NOT_EXIST, ERR_NOT_WRITEABLE, ERR_EXISTS, ERR_INCOMPLETE_RENAME, ERR_NOT_A_USER, ERR_TOO_MANY_PATHS"))
-      (svc/trap uri rename/do-rename params body))
+      (svc/trap uri rename/do-rename-uuid params body data-id))
 
     (POST* "/:data-id/metadata/save" [:as {uri :uri}]
       :path-params [data-id :- DataIdPathParam]

--- a/services/data-info/src/data_info/routes/domain/data.clj
+++ b/services/data-info/src/data_info/routes/domain/data.clj
@@ -13,12 +13,15 @@
       their files and subfolders) under the source folder will be included in the exported file,
       along with all of their metadata")})
 
-(s/defschema RenameRequest
-  {:source
+(s/defschema RenameResult
+  {:user
+   (describe NonBlankString "The user performing the request.")
+
+   :source
    (describe NonBlankString "An iRODS path to the initial location of the file being renamed.")
 
    :dest
    (describe NonBlankString "An iRODS path to the final location of the file being renamed.")})
 
-(s/defschema RenameResult
-  (assoc RenameRequest :user (describe NonBlankString "The user performing the request.")))
+(s/defschema Filename
+  {:filename (describe NonBlankString "The name of the file.")})


### PR DESCRIPTION
Remove data-info's POST /data/rename and instead provide a PUT /data/:data-id/name to set the name, for more reasonable RESTness. However, change Donkey to retain the current semantics for the UI.

This does mean it does a bit of a strange thing where the UI passes a path, which donkey turns into a UUID, which data-info turns back into a path. Since we want to be using UUIDs to identify files in general, the fix for this will be to modify the donkey endpoint and the UI to pass through UUIDs directly (as the UI already does for some other things), but for now I'm trying to keep the changes within the backend!