### PR TITLE
CORE-7091 Split authentication from authorization in Donkey

### DIFF
--- a/libs/clj-cas/src/clj_cas/cas_proxy_auth.clj
+++ b/libs/clj-cas/src/clj_cas/cas_proxy_auth.clj
@@ -113,8 +113,8 @@
     (str (apply curl/url (map #(string/replace % #"^/|/$" "") components)))))
 
 (defn validate-cas-proxy-ticket
-  "Authenticates a CAS proxy ticket.  If the proxy ticket can be validated then the request
-   is passed to the handler.  Otherwise, the handler responds with HTTP status code 401."
+  "Authenticates a CAS proxy ticket. If the proxy ticket can be validated then the request
+   is passed to the handler. Otherwise, the handler responds with HTTP status code 401."
   [handler ticket-fn cas-server-fn server-name-fn
    & [proxy-callback-base-fn proxy-callback-path-fn]]
   (let [ticket-fn        (or ticket-fn (constantly nil))
@@ -127,18 +127,6 @@
       (if (= (callback-path-fn) (:uri request))
         (handle-proxy-callback @pgt-storage request)
         (handle-authentication handler ticket-fn @validator (server-name-fn) request)))))
-
-(defn validate-cas-group-membership
-  "This is a convenience function that produces a handler that validates a CAS ticket, extracts
-   the group membership information from a user attribute and verifies that the user belongs to
-   one of the groups that are permitted to access the resource."
-  [handler ticket-fn cas-server-fn server-name-fn attr-name-fn allowed-groups-fn
-   & [proxy-callback-url-fn proxy-callback-path-fn]]
-  (-> handler
-    (validate-group-membership allowed-groups-fn)
-    (extract-groups-from-user-attributes attr-name-fn)
-    (validate-cas-proxy-ticket ticket-fn cas-server-fn server-name-fn proxy-callback-url-fn
-                               proxy-callback-path-fn)))
 
 (defn get-proxy-ticket
   "Obtains a proxy ticket that can be used to authenticate to other CAS-secured services."

--- a/libs/iplant-clojure-commons/src/clojure_commons/error_codes.clj
+++ b/libs/iplant-clojure-commons/src/clojure_commons/error_codes.clj
@@ -1,7 +1,6 @@
 (ns clojure-commons.error-codes
   (:use [slingshot.slingshot :only [try+]])
   (:require [clojure.tools.logging :as log]
-            [clojure-commons.exception :as cx]
             [cheshire.core :as cheshire]
             [clojure.string :as string])
   (:import [java.io PrintWriter
@@ -170,7 +169,6 @@
       (log/error (format-exception (:throwable &throw-context)))
       (err-resp action (:object &throw-context)))
     (catch clj-http-error? o o)
-    (catch [:type ::cx/invalid-cfg] {:keys [error]} (invalid-cfg-response error))
     (catch [:type :invalid-argument] {:keys [reason arg val]} (invalid-arg-response arg val reason))
     (catch [:type :ring.swagger.schema/validation] {:keys [error]} (validation-error-response error))
     (catch [:type :compojure.api.exception/request-validation] {:keys [error]} (validation-error-response error))

--- a/libs/service-logging/src/service_logging/middleware.clj
+++ b/libs/service-logging/src/service_logging/middleware.clj
@@ -24,6 +24,7 @@
   (dissoc request
           :body
           :user-info
+          :user-attributes
           :compojure.api.middleware/options
           :ring.swagger.middleware/data))
 


### PR DESCRIPTION
Also restructure how the middlewares were being applied. This was
necessary because some routes are secured while others are not.
So, there is a little duplication in the composed handlers (wrap
exceptions, logging, wrap user, etc).

CORE-7056
CORE-7091
CORE-7092