### PR TITLE
Core 7112,7113 Update metadactyl Access logging and exception handling

### DIFF
--- a/libs/iplant-clojure-commons/project.clj
+++ b/libs/iplant-clojure-commons/project.clj
@@ -18,5 +18,6 @@
                  [medley "0.7.0"]
                  [metosin/compojure-api "0.23.1"]
                  [slingshot "0.12.2"]
-                 [trptcolin/versioneer "0.2.0"]]
+                 [trptcolin/versioneer "0.2.0"]
+                 [org.iplantc/service-logging "5.0.0"]]
   :profiles {:test {:resource-paths ["resources" "test-resources"]}})

--- a/libs/iplant-clojure-commons/src/clojure_commons/exception.clj
+++ b/libs/iplant-clojure-commons/src/clojure_commons/exception.clj
@@ -1,16 +1,13 @@
 (ns clojure-commons.exception
-  (:use [slingshot.slingshot :only [get-throw-context]])
+  (:use [slingshot.slingshot :only [get-throw-context]]
+        [service-logging.thread-context :only [with-logging-context]
+         ])
   (:require [clojure-commons.error-codes :as ec]
             [cheshire.core :as cheshire]
             [compojure.api.exception :as ex]
             [ring.util.response :as header]
+            [service-logging.middleware :as smw]
             [ring.util.http-response :as resp]))
-
-(defn- embed-error-info
-  [throwable exception response]
-  (assoc response
-    :throwable throwable
-    :exception exception))
 
 (def ^:private clj-http-error?
   (every-pred :status :headers :body))
@@ -26,102 +23,115 @@
    a ':errors' subkey in the response ':body'"
   [error-handler error-code]
   (fn [error error-type request]
-    (let [response (error-handler error error-type request)
+    (let [hndlr-resp (error-handler error error-type request)
           exception {:error_code error-code
-                     :reason (get-in response [:body :errors])}]
-      (header/content-type
-        (embed-error-info error
-                          exception
-                          (assoc response
-                            :body (cheshire/encode exception)))
-        "application/json; charset=utf-8"))))
+                     :reason (get-in hndlr-resp [:body :errors])}
+          response (header/content-type
+                     (assoc hndlr-resp :body (cheshire/encode exception))
+                     "application/json; charset=utf-8")]
+      (smw/log-response-with-exception error
+                                       request
+                                       response
+                                       exception)
+      response)))
+
+(defn default-error-handler
+  "Produces an error handler which generates exceptions with the
+  given error-code and HTTP response function."
+  [response-fn error-code]
+  (fn [error error-type request]
+    (let [exception (merge {:error_code error-code
+                            :reason (:error error-type)}
+                           (dissoc error-type :type :error))
+          response (response-fn (cheshire/encode exception))]
+      (smw/log-response-with-exception error
+                                       request
+                                       response
+                                       exception)
+      response)))
 
 (defn authentication-not-found-handler
-  [error data _]
-  (resp/unauthorized
-    (let [exception {:error_code ec/ERR_NOT_AUTHORIZED
-                     :reason (:error data)}]
-      (header/header
-        (embed-error-info error
-                          exception
-                          (resp/unauthorized (cheshire/encode exception)))
-        "WWW-Authenticate"
-        "Custom"))))
+  [error data request]
+  (let [exception {:error_code ec/ERR_NOT_AUTHORIZED
+                     :reason (:error data)}
+          response (header/header
+                     (resp/unauthorized (cheshire/encode exception))
+                     "WWW-Authenticate"
+                     "Custom")]
+      (smw/log-response-with-exception error
+                                       request
+                                       response
+                                       exception)
+      response))
 
 (defn forbidden-handler
-  [error data _]
+  [error data request]
   (let [exception {:error_code ec/ERR_FORBIDDEN
-                   :reason     (:error data)}]
-    (header/header
-     (embed-error-info error
-                       exception
-                       (resp/forbidden (cheshire/encode exception)))
-     "WWW-Authenticate"
-     "Custom")))
+                   :reason     (:error data)}
+        response (header/header (resp/forbidden (cheshire/encode exception))
+                                "WWW-Authenticate"
+                                "Custom")]
+    (smw/log-response-with-exception error
+                                     request
+                                     response
+                                     exception)
+    response))
 
-(defn invalid-cfg-handler
-  [error error-type _]
-  (let [exception {:error_code ec/ERR_CONFIG_INVALID
-                   :reason (:error error-type)}]
-    (embed-error-info error
-                      exception
-                      (resp/internal-server-error (cheshire/encode exception)))))
+(def invalid-cfg-handler
+  (default-error-handler resp/internal-server-error ec/ERR_CONFIG_INVALID))
 
-(defn missing-request-field-handler
-  [error error-type _]
-  (let [exception {:error_code ec/ERR_BAD_OR_MISSING_FIELD
-                   :fields (:fields error-type)}]
-    (embed-error-info error
-                      exception
-                      (resp/bad-request (cheshire/encode exception)))))
+(defn illegal-argument-handler
+  [^IllegalArgumentException error error-type request]
+  (let [exception {:error_code ec/ERR_ILLEGAL_ARGUMENT
+                   :reason (.toString error)}
+        response (resp/bad-request (cheshire/encode exception))]
+    (smw/log-response-with-exception error
+                                     request
+                                     response
+                                     exception)
+    response))
 
-(defn bad-request-field-handler
-  [error error-data request]
-  (missing-request-field-handler error error-data request))
+(def missing-request-field-handler
+  (default-error-handler resp/bad-request ec/ERR_BAD_OR_MISSING_FIELD))
 
-(defn missing-query-params-handler
-  [error error-type _]
-  (let [exception {:error_code ec/ERR_MISSING_QUERY_PARAMETER
-                   :parameters (:parameters error-type)}]
-    (embed-error-info error
-                      exception
-                      (resp/bad-request (cheshire/encode exception)))))
+(def bad-request-field-handler
+  (default-error-handler resp/bad-request ec/ERR_BAD_OR_MISSING_FIELD))
 
-(defn bad-query-params-handler
-  [error error-type _]
-  (let [exception {:error_code ec/ERR_BAD_QUERY_PARAMETER
-                   :parameters (:parameters error-type)}]
-    (embed-error-info error
-                      exception
-                      (resp/bad-request (cheshire/encode exception)))))
+(def missing-query-params-handler
+  (default-error-handler resp/bad-request ec/ERR_MISSING_QUERY_PARAMETER))
 
-(defn unchecked-handler
-  [error error-type _]
-  (let [error-obj (:object (get-throw-context error))]
-    (cond
-     (ec/error? error-obj)
-     (embed-error-info error
-                       error-obj
-                       (resp/internal-server-error (cheshire/encode error-obj)))
+(def bad-query-params-handler
+  (default-error-handler resp/bad-request ec/ERR_BAD_QUERY_PARAMETER))
 
-     (clj-http-error? error-obj)
-     (embed-error-info error
-                       {:error_code ec/ERR_REQUEST_FAILED}
-                       error-obj)
+(def not-found-handler
+  (default-error-handler resp/not-found ec/ERR_NOT_FOUND))
 
-      (instance? Exception error)
-      (let [exception {:error_code ec/ERR_UNCHECKED_EXCEPTION
-                       :reason (.toString error)}]
-        (embed-error-info error
-                          exception
-                          (resp/internal-server-error (cheshire/encode exception))))
+(def failed-dependency-handler
+  (default-error-handler resp/failed-dependency ec/ERR_MISSING_DEPENDENCY))
 
-     (instance? Object error)
-     (let [exception {:error_code ec/ERR_UNCHECKED_EXCEPTION
-                      :reason (:message error-type)}]
-       (embed-error-info error
-                         exception
-                         (resp/internal-server-error (cheshire/encode exception)))))))
+(def temporary-redirect-handler
+  (default-error-handler resp/bad-request ec/ERR_TEMPORARILY_MOVED))
+
+(def not-writeable-handler
+  (default-error-handler resp/bad-request ec/ERR_NOT_WRITEABLE))
+
+(def not-authorized-handler
+  (default-error-handler resp/not-found ec/ERR_NOT_AUTHORIZED))
+
+(def invalid-json-handler
+  (default-error-handler resp/bad-request ec/ERR_INVALID_JSON))
+
+(def request-failed-handler
+  (default-error-handler resp/internal-server-error ec/ERR_REQUEST_FAILED))
+
+(def unavailable-handler
+  (default-error-handler resp/gateway-timeout ec/ERR_UNAVAILABLE))
+
+(def not-owner-handler
+  (default-error-handler resp/forbidden ec/ERR_NOT_OWNER))
+
+(def item-exists-handler
+  (default-error-handler resp/bad-request ec/ERR_EXISTS))
 
 (def handle-request-validation-errors
   (as-de-exception-handler ex/request-validation-handler ec/ERR_ILLEGAL_ARGUMENT))
@@ -129,15 +139,73 @@
 (def handle-response-validation-errors
   (as-de-exception-handler ex/response-validation-handler ec/ERR_SCHEMA_VALIDATION))
 
+(defn unchecked-handler
+  [error error-type request]
+  (let [error-obj (:object (get-throw-context error))]
+    (cond
+      (ec/error? error-obj)
+      (let [exception error-obj
+            response (resp/internal-server-error (cheshire/encode error-obj))]
+        (smw/log-response-with-exception error
+                                         request
+                                         response
+                                         exception)
+        response)
+
+      (clj-http-error? error-obj)
+      (let [exception {:error_code ec/ERR_REQUEST_FAILED}
+            response error-obj]
+        (smw/log-response-with-exception error
+                                         request
+                                         response
+                                         exception)
+        response)
+
+      (instance? IllegalArgumentException error)
+      (illegal-argument-handler error error-type request)
+
+      (instance? Exception error)
+      (let [exception {:error_code ec/ERR_UNCHECKED_EXCEPTION
+                       :reason (.toString error)}
+            response (resp/internal-server-error (cheshire/encode exception))]
+        (smw/log-response-with-exception error
+                                         request
+                                         response
+                                         exception)
+        response)
+
+      (instance? Object error)
+      (let [exception {:error_code ec/ERR_UNCHECKED_EXCEPTION
+                       :reason (:message error-type)}
+            response (resp/internal-server-error (cheshire/encode exception))]
+        (smw/log-response-with-exception error
+                                         request
+                                         response
+                                         exception)
+        response))))
+
 (def exception-handlers
   {:handlers
    {::ex/request-validation    handle-request-validation-errors
     ::ex/response-validation   handle-response-validation-errors
+    ::exists                   item-exists-handler
+    ::failed-dependency        failed-dependency-handler
+    ::illegal-argument         illegal-argument-handler
+    ::not-found                not-found-handler
     ::invalid-cfg              invalid-cfg-handler
+    ::invalid-json             invalid-json-handler
     ::authentication-not-found authentication-not-found-handler
+    ::not-authorized           not-authorized-handler
+    ::not-owner                not-owner-handler
+    ::not-writeable            not-writeable-handler
     ::forbidden                forbidden-handler
     ::missing-request-field    missing-request-field-handler
     ::bad-request-field        bad-request-field-handler
     ::missing-query-params     missing-query-params-handler
     ::bad-query-params         bad-query-params-handler
+    ::request-failed           request-failed-handler
+    ::temporary-redirect       temporary-redirect-handler
+    ::unavailable              unavailable-handler
     ::ex/default               unchecked-handler}})
+
+

--- a/libs/iplant-clojure-commons/src/clojure_commons/exception.clj
+++ b/libs/iplant-clojure-commons/src/clojure_commons/exception.clj
@@ -1,7 +1,6 @@
 (ns clojure-commons.exception
   (:use [slingshot.slingshot :only [get-throw-context]]
-        [service-logging.thread-context :only [with-logging-context]
-         ])
+        [service-logging.thread-context :only [with-logging-context]])
   (:require [clojure-commons.error-codes :as ec]
             [cheshire.core :as cheshire]
             [compojure.api.exception :as ex]
@@ -26,118 +25,110 @@
     (let [hndlr-resp (error-handler error error-type request)
           exception {:error_code error-code
                      :reason (get-in hndlr-resp [:body :errors])}
-          response (header/content-type
-                     (assoc hndlr-resp :body (cheshire/encode exception))
-                     "application/json; charset=utf-8")]
+          response (-> hndlr-resp
+                       (assoc :body (cheshire/encode exception))
+                       (header/content-type "application/json; charset=utf-8"))]
       (smw/log-response-with-exception error
                                        request
                                        response
                                        exception)
       response)))
+
+(defn- exception-with-reason
+  ([error-code reason]
+   (exception-with-reason error-code reason {}))
+  ([error-code reason m]
+   (assoc m
+     :error_code error-code
+     :reason     reason)))
+
+(defn- apply-headers
+  [response headers-map]
+  (reduce (fn [response [header-name header-value]]
+            (header/header response header-name header-value))
+          response headers-map))
 
 (defn default-error-handler
   "Produces an error handler which generates exceptions with the
   given error-code and HTTP response function."
-  [response-fn error-code]
+  [response-fn error-code & [header-map]]
   (fn [error error-type request]
-    (let [exception (merge {:error_code error-code
-                            :reason (:error error-type)}
-                           (dissoc error-type :type :error))
-          response (response-fn (cheshire/encode exception))]
-      (smw/log-response-with-exception error
-                                       request
-                                       response
-                                       exception)
+    (let [reason    (:error error-type)
+          exception (exception-with-reason error-code reason (dissoc error-type :type :error))
+          response  (apply-headers (response-fn (cheshire/encode exception)) header-map)]
+      (smw/log-response-with-exception error request response exception)
       response)))
 
-(defn authentication-not-found-handler
-  [error data request]
-  (let [exception {:error_code ec/ERR_NOT_AUTHORIZED
-                     :reason (:error data)}
-          response (header/header
-                     (resp/unauthorized (cheshire/encode exception))
-                     "WWW-Authenticate"
-                     "Custom")]
-      (smw/log-response-with-exception error
-                                       request
-                                       response
-                                       exception)
-      response))
-
-(defn forbidden-handler
-  [error data request]
-  (let [exception {:error_code ec/ERR_FORBIDDEN
-                   :reason     (:error data)}
-        response (header/header (resp/forbidden (cheshire/encode exception))
-                                "WWW-Authenticate"
-                                "Custom")]
-    (smw/log-response-with-exception error
-                                     request
-                                     response
-                                     exception)
+(defn temporary-redirect-handler
+  "Specialized exception handler for 302 responses. This could not be accomplished with the default
+   exception handler because best practices for 302 responses is an empty response body."
+  [error error-type request]
+  (let [reason (:error error-type)
+        exception (exception-with-reason ec/ERR_TEMPORARILY_MOVED reason (dissoc error-type :type :error))
+        location (:location error-type)
+        response (resp/found location)]
+    (smw/log-response-with-exception error request response exception)
     response))
 
-(def invalid-cfg-handler
-  (default-error-handler resp/internal-server-error ec/ERR_CONFIG_INVALID))
-
-(defn illegal-argument-handler
-  [^IllegalArgumentException error error-type request]
-  (let [exception {:error_code ec/ERR_ILLEGAL_ARGUMENT
-                   :reason (.toString error)}
-        response (resp/bad-request (cheshire/encode exception))]
-    (smw/log-response-with-exception error
-                                     request
-                                     response
-                                     exception)
-    response))
-
-(def missing-request-field-handler
-  (default-error-handler resp/bad-request ec/ERR_BAD_OR_MISSING_FIELD))
-
-(def bad-request-field-handler
-  (default-error-handler resp/bad-request ec/ERR_BAD_OR_MISSING_FIELD))
-
-(def missing-query-params-handler
-  (default-error-handler resp/bad-request ec/ERR_MISSING_QUERY_PARAMETER))
+(def authentication-not-found-handler
+  (default-error-handler resp/unauthorized ec/ERR_NOT_AUTHORIZED {"WWW-Authenticate" "Custom"}))
 
 (def bad-query-params-handler
   (default-error-handler resp/bad-request ec/ERR_BAD_QUERY_PARAMETER))
 
-(def not-found-handler
-  (default-error-handler resp/not-found ec/ERR_NOT_FOUND))
+(def bad-request-field-handler
+  (default-error-handler resp/bad-request ec/ERR_BAD_OR_MISSING_FIELD))
 
 (def failed-dependency-handler
   (default-error-handler resp/failed-dependency ec/ERR_MISSING_DEPENDENCY))
 
-(def temporary-redirect-handler
-  (default-error-handler resp/bad-request ec/ERR_TEMPORARILY_MOVED))
-
-(def not-writeable-handler
-  (default-error-handler resp/bad-request ec/ERR_NOT_WRITEABLE))
-
-(def not-authorized-handler
-  (default-error-handler resp/not-found ec/ERR_NOT_AUTHORIZED))
-
-(def invalid-json-handler
-  (default-error-handler resp/bad-request ec/ERR_INVALID_JSON))
-
-(def request-failed-handler
-  (default-error-handler resp/internal-server-error ec/ERR_REQUEST_FAILED))
-
-(def unavailable-handler
-  (default-error-handler resp/gateway-timeout ec/ERR_UNAVAILABLE))
-
-(def not-owner-handler
-  (default-error-handler resp/forbidden ec/ERR_NOT_OWNER))
-
-(def item-exists-handler
-  (default-error-handler resp/bad-request ec/ERR_EXISTS))
+(def forbidden-handler
+  (default-error-handler resp/forbidden ec/ERR_FORBIDDEN {"WWW-Authenticate" "Custom"}))
 
 (def handle-request-validation-errors
   (as-de-exception-handler ex/request-validation-handler ec/ERR_ILLEGAL_ARGUMENT))
 
 (def handle-response-validation-errors
   (as-de-exception-handler ex/response-validation-handler ec/ERR_SCHEMA_VALIDATION))
+
+(def illegal-argument-handler
+  (default-error-handler resp/bad-request ec/ERR_ILLEGAL_ARGUMENT))
+
+(def invalid-cfg-handler
+  (default-error-handler resp/internal-server-error ec/ERR_CONFIG_INVALID))
+
+(def invalid-json-handler
+  (default-error-handler resp/bad-request ec/ERR_INVALID_JSON))
+
+(def item-exists-handler
+  (default-error-handler resp/bad-request ec/ERR_EXISTS))
+
+(def missing-query-params-handler
+  (default-error-handler resp/bad-request ec/ERR_MISSING_QUERY_PARAMETER))
+
+(def missing-request-field-handler
+  (default-error-handler resp/bad-request ec/ERR_BAD_OR_MISSING_FIELD))
+
+(def not-authorized-handler
+  (default-error-handler resp/unauthorized ec/ERR_NOT_AUTHORIZED))
+
+(def not-found-handler
+  (default-error-handler resp/not-found ec/ERR_NOT_FOUND))
+
+(def not-owner-handler
+  (default-error-handler resp/forbidden ec/ERR_NOT_OWNER))
+
+(def not-writeable-handler
+  (default-error-handler resp/bad-request ec/ERR_NOT_WRITEABLE))
+
+(def not-a-user-handler
+  (default-error-handler resp/not-found ec/ERR_NOT_A_USER))
+
+(def request-failed-handler
+  (default-error-handler resp/internal-server-error ec/ERR_REQUEST_FAILED))
+
+(def unavailable-handler
+  (default-error-handler resp/gateway-timeout ec/ERR_UNAVAILABLE))
 
 (defn unchecked-handler
   [error error-type request]
@@ -162,7 +153,14 @@
         response)
 
       (instance? IllegalArgumentException error)
-      (illegal-argument-handler error error-type request)
+      (let [exception {:error_code ec/ERR_ILLEGAL_ARGUMENT
+                       :reason (.toString error)}
+            response (resp/bad-request (cheshire/encode exception))]
+        (smw/log-response-with-exception error
+                                         request
+                                         response
+                                         exception)
+        response)
 
       (instance? Exception error)
       (let [exception {:error_code ec/ERR_UNCHECKED_EXCEPTION
@@ -196,6 +194,7 @@
     ::invalid-json             invalid-json-handler
     ::authentication-not-found authentication-not-found-handler
     ::not-authorized           not-authorized-handler
+    ::not-a-user               not-a-user-handler
     ::not-owner                not-owner-handler
     ::not-writeable            not-writeable-handler
     ::forbidden                forbidden-handler

--- a/libs/iplant-clojure-commons/src/clojure_commons/response.clj
+++ b/libs/iplant-clojure-commons/src/clojure_commons/response.clj
@@ -20,5 +20,3 @@
   "Returns an HTTP response indicating that the user is not permitted to access a resource."
   [reason]
   (error-response http-resp/forbidden ce/ERR_FORBIDDEN :reason reason))
-
-

--- a/libs/iplant-clojure-commons/src/clojure_commons/response.clj
+++ b/libs/iplant-clojure-commons/src/clojure_commons/response.clj
@@ -20,3 +20,5 @@
   "Returns an HTTP response indicating that the user is not permitted to access a resource."
   [reason]
   (error-response http-resp/forbidden ce/ERR_FORBIDDEN :reason reason))
+
+

--- a/libs/iplant-clojure-commons/src/clojure_commons/validators.clj
+++ b/libs/iplant-clojure-commons/src/clojure_commons/validators.clj
@@ -68,12 +68,14 @@
 
 (defn- throw-missing-params
   [params]
-  (throw+ {:type ::cx/missing-query-params, :parameters params}))
+  (throw+ {:type   ::cx/missing-query-params
+           :parameters params}))
 
 
 (defn- throw-bad-params
   [params]
-  (throw+ {:type ::cx/bad-query-params, :parameters params}))
+  (throw+ {:type ::cx/bad-query-params
+           :parameters params}))
 
 
 (defn validate-query-params

--- a/libs/mescal/src/mescal/agave_v2.clj
+++ b/libs/mescal/src/mescal/agave_v2.clj
@@ -10,6 +10,7 @@
             [mescal.util :as util])
   (:import [java.io IOException]))
 
+; FIXME Update metadactyl exception handling when this exception handling is updated
 (defn- agave-unavailable
   [e]
   (let [msg "Agave appears to be unavailable at this time"]

--- a/libs/service-logging/src/service_logging/middleware.clj
+++ b/libs/service-logging/src/service_logging/middleware.clj
@@ -93,7 +93,7 @@
 
 (defn add-user-to-context
   "add-user-to-context is a ring handler that adds the user value from the query
-  string into the context with a key of 'user'. The query params need to be parsed first."
+  string into the context with a key of 'user-info user'. The query params need to be parsed first."
   [handler]
   (fn [{:keys [query-params] :as request}]
     (if (contains? query-params "user")

--- a/libs/service-logging/src/service_logging/middleware.clj
+++ b/libs/service-logging/src/service_logging/middleware.clj
@@ -95,12 +95,11 @@
   "add-user-to-context is a ring handler that adds the user value from the query
   string into the context with a key of 'user'. The query params need to be parsed first."
   [handler]
-  (fn [request]
-    (let [q-params (:query-params request)]
-      (if (contains? q-params "user")
-        (tc/with-logging-context (assoc-in {} [:user-info :user](get (:query-params request) "user"))
-                              (handler request))
-        (handler request)))))
+  (fn [{:keys [query-params] :as request}]
+    (if (contains? query-params "user")
+      (tc/with-logging-context (assoc-in {} [:user-info :user](get query-params "user"))
+                               (handler request))
+      (handler request))))
 
 ; FIXME Replace usages of this function with compojure api validation exception handlers
 (defn log-validation-errors

--- a/libs/service-logging/src/service_logging/middleware.clj
+++ b/libs/service-logging/src/service_logging/middleware.clj
@@ -71,6 +71,19 @@
   [handler]
   (fn [request]
     (log-request request)
+    (let [response (handler request)]
+      (log-response request response)
+      response)))
+
+(defn wrap-response-logging
+  "Logs incoming requests and their responses with the 'AccessLogger' logger.
+
+    If the response map contains a `throwable` key, the value will be given to
+    the logger as an exception/throwable. Also, if the `throwable` key is not nil,
+    it is assumed that there will also be an `exception` key in the response map.
+    The `throwable` and `exception` keys are not logged nor passed with the response."
+  [handler]
+  (fn [request]
     (let [{:keys [throwable exception] :as response} (handler request)]
       (if (nil? throwable)
                (log-response request response)

--- a/libs/service-logging/src/service_logging/thread_context.clj
+++ b/libs/service-logging/src/service_logging/thread_context.clj
@@ -30,13 +30,3 @@
          (if ctx#
            (MDC/setContextMap ctx#)
            (clear-context!))))))
-
-(defn add-user-to-context
-  "add-user-to-context is a ring handler that adds the user value from the query
-  string into the context with a key of 'user'. The query params need to be parsed first."
-  [handler]
-  (fn [request]
-    (let [q-params (:query-params request)]
-      (if (contains? q-params "user")
-        (set-context! {:user (get (:query-params request) "user")}))
-      (handler request))))

--- a/project-defs.edn
+++ b/project-defs.edn
@@ -59,7 +59,7 @@
 
  "service-logging"
  {:type     :library
-  :type-num 12
+  :type-num 4
   :path     "libs/service-logging"
   :build    :lein
   :install  :lein

--- a/project-defs.edn
+++ b/project-defs.edn
@@ -57,6 +57,18 @@
   :language :clojure
   :archive? false}
 
+ "service-logging"
+ {:type     :library
+  :type-num 12
+  :path     "libs/service-logging"
+  :build    :lein
+  :install  :lein
+  :tarball? false
+  :uberjar? false
+  :install? true
+  :language :clojure
+  :archive? false}
+
  "iplant-clojure-commons"
  {:type     :library
   :type-num 5
@@ -133,18 +145,6 @@
  {:type     :library
   :type-num 11
   :path     "libs/mescal"
-  :build    :lein
-  :install  :lein
-  :tarball? false
-  :uberjar? false
-  :install? true
-  :language :clojure
-  :archive? false}
-
- "service-logging"
- {:type     :library
-  :type-num 12
-  :path     "libs/service-logging"
   :build    :lein
   :install  :lein
   :tarball? false

--- a/services/Donkey/src/donkey/core.clj
+++ b/services/Donkey/src/donkey/core.clj
@@ -189,27 +189,27 @@
       (wrap-routes authenticate-current-user)
       (wrap-routes wrap-user-info)
       (wrap-routes validate-current-user)
-      (wrap-routes wrap-logging)
-      (wrap-routes wrap-exceptions  cx/exception-handlers)))
+      (wrap-routes wrap-exceptions  cx/exception-handlers)
+      (wrap-routes wrap-logging)))
 
 (def secured-routes-handler
   (-> (delayed-handler secured-routes)
       (wrap-routes authenticate-current-user)
       (wrap-routes wrap-user-info)
-      (wrap-routes wrap-logging)
-      (wrap-routes wrap-exceptions  cx/exception-handlers)))
+      (wrap-routes wrap-exceptions  cx/exception-handlers)
+      (wrap-routes wrap-logging)))
 
 (def secured-routes-no-context-handler
   (-> (delayed-handler secured-routes-no-context)
       (wrap-routes authenticate-current-user)
       (wrap-routes wrap-user-info)
-      (wrap-routes wrap-logging)
-      (wrap-routes wrap-exceptions  cx/exception-handlers)))
+      (wrap-routes wrap-exceptions  cx/exception-handlers)
+      (wrap-routes wrap-logging)))
 
 (def unsecured-routes-handler
   (-> (delayed-handler unsecured-routes)
-      (wrap-routes wrap-logging)
-      (wrap-routes wrap-exceptions cx/exception-handlers)))
+      (wrap-routes wrap-exceptions cx/exception-handlers)
+      (wrap-routes wrap-logging)))
 
 (defn donkey-routes
   []

--- a/services/NotificationAgent/src/notification_agent/core.clj
+++ b/services/NotificationAgent/src/notification_agent/core.clj
@@ -3,7 +3,7 @@
   (:use [clojure.java.io :only [file]]
         [clojure-commons.lcase-params :only [wrap-lcase-params]]
         [clojure-commons.query-params :only [wrap-query-params]]
-        [service-logging.middleware :only [wrap-logging]]
+        [service-logging.middleware :only [wrap-logging add-user-to-context]]
         [compojure.core]
         [korma.db :only [transaction]]
         [ring.middleware keyword-params nested-params]
@@ -157,7 +157,7 @@
 
 (defn site-handler [routes]
   (-> routes
-      tc/add-user-to-context
+      add-user-to-context
       wrap-keyword-params
       wrap-lcase-params
       wrap-nested-params

--- a/services/data-info/src/data_info/routes.clj
+++ b/services/data-info/src/data_info/routes.clj
@@ -3,7 +3,7 @@
         [clojure-commons.query-params :only [wrap-query-params]]
         [common-swagger-api.schema]
         [compojure.api.middleware :only [wrap-exceptions]]
-        [service-logging.middleware :only [log-validation-errors]]
+        [service-logging.middleware :only [log-validation-errors add-user-to-context]]
         [ring.util.response :only [redirect]])
   (:require [compojure.route :as route]
             [clojure-commons.exception :as cx]
@@ -19,8 +19,7 @@
             [data-info.util :as util]
             [data-info.util.config :as config]
             [data-info.util.service :as svc]
-            [ring.middleware.keyword-params :as params]
-            [service-logging.thread-context :as tc]))
+            [ring.middleware.keyword-params :as params]))
 
 (defapi app
   (swagger-ui config/docs-uri)
@@ -36,7 +35,7 @@
             {:name "filetypes", :description "File Type Metadata"}
             {:name "home", :description "User Home Directories"}]})
   (middlewares
-    [tc/add-user-to-context
+    [add-user-to-context
      wrap-query-params
      wrap-lcase-params
      params/wrap-keyword-params

--- a/services/data-info/src/data_info/routes/stats.clj
+++ b/services/data-info/src/data_info/routes/stats.clj
@@ -9,6 +9,8 @@
 
 (defroutes* stat-gatherer
 
+            ; FIXME Update metadactyl exception handling when data-info excptn hndlg updated
+            ; metadactyl catches exceptions thrown from this EP.
   (context* "/stat-gatherer" []
     :tags ["bulk"]
 

--- a/services/metadactyl-clj/project.clj
+++ b/services/metadactyl-clj/project.clj
@@ -44,4 +44,5 @@
   :repositories [["sonatype-nexus-snapshots"
                   {:url "https://oss.sonatype.org/content/repositories/snapshots"}]]
   :deploy-repositories [["sonatype-nexus-staging"
-                         {:url "https://oss.sonatype.org/service/local/staging/deploy/maven2/"}]])
+                         {:url "https://oss.sonatype.org/service/local/staging/deploy/maven2/"}]]
+  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/metadactyl-logging.xml"])

--- a/services/metadactyl-clj/src/metadactyl/app_listings.clj
+++ b/services/metadactyl-clj/src/metadactyl/app_listings.clj
@@ -13,11 +13,7 @@
         [metadactyl.util.assertions :only [assert-not-nil]]
         [metadactyl.util.config]
         [metadactyl.util.conversions :only [to-long remove-nil-vals]]
-        [metadactyl.workspace])
-  (:require [cemerick.url :as curl]
-            [cheshire.core :as cheshire]
-            [clojure.tools.logging :as log]
-            [metadactyl.util.service :as service]))
+        [metadactyl.workspace]))
 
 (def my-public-apps-id (uuidify "00000000-0000-0000-0000-000000000000"))
 (def trash-category-id (uuidify "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"))

--- a/services/metadactyl-clj/src/metadactyl/clients/data_info.clj
+++ b/services/metadactyl-clj/src/metadactyl/clients/data_info.clj
@@ -3,7 +3,6 @@
             [cheshire.core :as cheshire]
             [clj-http.client :as http]
             [clojure.string :as string]
-            [clojure.tools.logging :as log]
             [metadactyl.util.config :as config]
             [metadactyl.util.service :as service]))
 

--- a/services/metadactyl-clj/src/metadactyl/clients/iplant_groups.clj
+++ b/services/metadactyl-clj/src/metadactyl/clients/iplant_groups.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.clients.iplant-groups
   (:require [cemerick.url :as curl]
             [clj-http.client :as http]
-            [clojure.tools.logging :as log]
             [metadactyl.util.config :as config]))
 
 (defn- lookup-subject-url

--- a/services/metadactyl-clj/src/metadactyl/kormadb.clj
+++ b/services/metadactyl-clj/src/metadactyl/kormadb.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.kormadb
   (:use [korma.db]
-        [metadactyl.util.config])
-  (:require [clojure.tools.logging :as log]))
+        [metadactyl.util.config]))
 
 (defn- create-db-spec
   "Creates the database connection spec to use when accessing the database

--- a/services/metadactyl-clj/src/metadactyl/metadata/element_listings.clj
+++ b/services/metadactyl-clj/src/metadactyl/metadata/element_listings.clj
@@ -147,5 +147,5 @@
     (cond
       (= elm-type "all")               (list-all params)
       (contains? listing-fns elm-type) ((listing-fns elm-type) params)
-      :else                            (throw+ {:type ::unrecognized_workflow_component_type
-                                                :name elm-type})))
+      :else (throw+ {:type ::unrecognized_workflow_component_type
+                     :name elm-type})))

--- a/services/metadactyl-clj/src/metadactyl/metadata/element_listings.clj
+++ b/services/metadactyl-clj/src/metadactyl/metadata/element_listings.clj
@@ -5,9 +5,7 @@
         [korma.core :exclude [update]]
         [metadactyl.tools :only [tool-listing-base-query]]
         [metadactyl.util.conversions :only [remove-nil-vals]]
-        [slingshot.slingshot :only [throw+]])
-  (:require [cheshire.core :as cheshire]
-            [metadactyl.util.service :as service]))
+        [slingshot.slingshot :only [throw+]]))
 
 (defn- base-parameter-type-query
   "Creates the base query used to list parameter types for the metadata element listing service."
@@ -146,9 +144,8 @@
   (defn list-elements "Lists selected workflow elements.  This function handles requests to list
    various different types of workflow elements."
   [elm-type params]
-  (service/success-response
     (cond
       (= elm-type "all")               (list-all params)
       (contains? listing-fns elm-type) ((listing-fns elm-type) params)
       :else                            (throw+ {:type ::unrecognized_workflow_component_type
-                                                :name elm-type}))))
+                                                :name elm-type})))

--- a/services/metadactyl-clj/src/metadactyl/metadata/reference_genomes.clj
+++ b/services/metadactyl-clj/src/metadactyl/metadata/reference_genomes.clj
@@ -109,17 +109,18 @@
   "Validates a single field in a reference genome."
   [genome field]
   (when (blank? (genome field))
-    (throw+ {:type       :clojure-commons.exception/missing-request-field
-             :error      "empty required field"
-             :genome genome})))
+    (throw+ {:type          :clojure-commons.exception/missing-request-field
+             :error         (str "empty required field: " field)
+             :missing-field field
+             :genome        genome})))
 
 (defn- validate-username
   "Validates a username field in a reference genome."
   [genome field]
   (let [username (genome field)]
     (when-not (or (= "<public>" username) (re-find #"@" username))
-      (throw+ {:type       :clojure-commons.exception/missing-request-field
-               :error      "username not fully qualified"
+      (throw+ {:type   :clojure-commons.exception/missing-request-field
+               :error  "username not fully qualified"
                :genome genome}))))
 
 (defn- validate-reference-genome

--- a/services/metadactyl-clj/src/metadactyl/metadata/reference_genomes.clj
+++ b/services/metadactyl-clj/src/metadactyl/metadata/reference_genomes.clj
@@ -8,10 +8,8 @@
         [metadactyl.user :only [current-user]]
         [metadactyl.util.assertions :only [assert-not-nil]]
         [metadactyl.util.conversions :only [date->timestamp]]
-        [metadactyl.util.service :only [success-response]]
         [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as error-codes]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [korma.core :as sql]))
 
 (defn- reference-genome-base-query
@@ -55,7 +53,7 @@
    (list-reference-genomes nil))
   ([params]
    (let [reference-genomes (get-reference-genomes params)]
-     (success-response {:genomes reference-genomes}))))
+     {:genomes reference-genomes})))
 
 (defn- get-valid-reference-genome
   [reference-genome-id]
@@ -65,7 +63,7 @@
 (defn get-reference-genome
   "Gets a reference genome by its ID."
   [reference-genome-id]
-  (success-response (get-valid-reference-genome reference-genome-id)))
+  (get-valid-reference-genome reference-genome-id))
 
 (defn delete-reference-genome
   "Logically deletes a reference genome by setting its 'deleted' flag to true."
@@ -111,8 +109,8 @@
   "Validates a single field in a reference genome."
   [genome field]
   (when (blank? (genome field))
-    (throw+ {:error_code error-codes/ERR_BAD_OR_MISSING_FIELD
-             field "empty required field"
+    (throw+ {:type       :clojure-commons.exception/missing-request-field
+             :error      "empty required field"
              :genome genome})))
 
 (defn- validate-username
@@ -120,8 +118,8 @@
   [genome field]
   (let [username (genome field)]
     (when-not (or (= "<public>" username) (re-find #"@" username))
-      (throw+ {:error_code error-codes/ERR_BAD_OR_MISSING_FIELD
-               field "username not fully qualified"
+      (throw+ {:type       :clojure-commons.exception/missing-request-field
+               :error      "username not fully qualified"
                :genome genome}))))
 
 (defn- validate-reference-genome

--- a/services/metadactyl-clj/src/metadactyl/metadata/tool_requests.clj
+++ b/services/metadactyl-clj/src/metadactyl/metadata/tool_requests.clj
@@ -6,9 +6,7 @@
         [metadactyl.user :only [load-user]]
         [metadactyl.util.conversions :only [remove-nil-vals]]
         [slingshot.slingshot :only [throw+]])
-  (:require [cheshire.core :as cheshire]
-            [clojure.string :as string]
-            [clojure-commons.error-codes :as error-codes]
+  (:require [clojure.string :as string]
             [kameleon.queries :as queries]
             [metadactyl.clients.notifications :as cn]
             [metadactyl.util.params :as params])
@@ -22,7 +20,7 @@
   [m & ks]
   (let [v (first (remove string/blank? (map m ks)))]
     (when (nil? v)
-      (throw+ {:error_code    error-codes/ERR_BAD_OR_MISSING_FIELD
+      (throw+ {:type :clojure-commons.exception/missing-request-field
                :accepted_keys ks}))
     v))
 
@@ -31,8 +29,8 @@
   [architecture]
   (let [id (:id (first (select tool_architectures (where {:name architecture}))))]
     (when (nil? id)
-      (throw+ {:error_code error-codes/ERR_NOT_FOUND
-               :name architecture}))
+      (throw+ {:type :clojure-commons.exception/not-found
+               :error (str "Could not locate ID for the architecture name: " architecture)}))
     id))
 
 (defn- status-code-subselect
@@ -78,8 +76,8 @@
   [uuid]
   (let [req (queries/get-tool-request-details uuid)]
     (when (nil? req)
-      (throw+ {:error_code error-codes/ERR_NOT_FOUND
-               :id   (string/upper-case (.toString uuid))}))
+      (throw+ {:type :clojure-commons.exception/not-found
+               :error (str "Could not locate tool with the following id: " (string/upper-case (.toString uuid)))}))
     req))
 
 (defn- get-most-recent-status
@@ -96,8 +94,8 @@
                         (order :trs.date_assigned :DESC)
                         (limit 1)))]
     (when (nil? status)
-      (throw+ {:error_code error-codes/ERR_MISSING_DEPENDENCY
-               :message "no status found for tool request"
+      (throw+ {:type :clojure-commons.exception/failed-dependency
+               :error "no status found for tool request"
                :id (string/upper-case (.toString uuid))}))
     status))
 

--- a/services/metadactyl-clj/src/metadactyl/metadata/tool_requests.clj
+++ b/services/metadactyl-clj/src/metadactyl/metadata/tool_requests.clj
@@ -29,7 +29,7 @@
   [architecture]
   (let [id (:id (first (select tool_architectures (where {:name architecture}))))]
     (when (nil? id)
-      (throw+ {:type :clojure-commons.exception/not-found
+      (throw+ {:type  :clojure-commons.exception/not-found
                :error (str "Could not locate ID for the architecture name: " architecture)}))
     id))
 

--- a/services/metadactyl-clj/src/metadactyl/persistence/app_metadata.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/app_metadata.clj
@@ -8,7 +8,6 @@
         [metadactyl.util.assertions]
         [metadactyl.util.conversions :only [remove-nil-vals]])
   (:require [clojure.set :as set]
-            [clojure.tools.logging :as log]
             [kameleon.app-listing :as app-listing]
             [korma.core :as sql]
             [metadactyl.persistence.app-metadata.delete :as delete]

--- a/services/metadactyl-clj/src/metadactyl/persistence/app_metadata/relabel.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/app_metadata/relabel.clj
@@ -9,10 +9,7 @@
                                             remove-nil-vals]]
         [metadactyl.util.assertions]
         [slingshot.slingshot :only [throw+]])
-  (:require [cheshire.core :as cheshire]
-            [clojure.string :as string]
-            [clojure-commons.error-codes :as ce]
-            [korma.core :as sql]))
+  (:require [korma.core :as sql]))
 
 (defn- get-single-task-for-app
   "Retrieves the task from a single-step app. An exception will be thrown if the app doesn't have
@@ -20,9 +17,9 @@
   [app-id]
   (let [tasks (get-tasks-for-app app-id)]
     (when (not= 1 (count tasks))
-      (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-               :reason     :NOT_SINGLE_STEP_APP
-               :step_count (count tasks)}))
+      (throw+ {:type :clojure-commons.exception/illegal-argument
+               :error     :NOT_SINGLE_STEP_APP
+               ::step_count (count tasks)}))
     (first tasks)))
 
 (defn- get-parameter-group-in-task

--- a/services/metadactyl-clj/src/metadactyl/persistence/app_metadata/relabel.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/app_metadata/relabel.clj
@@ -17,9 +17,9 @@
   [app-id]
   (let [tasks (get-tasks-for-app app-id)]
     (when (not= 1 (count tasks))
-      (throw+ {:type :clojure-commons.exception/illegal-argument
-               :error     :NOT_SINGLE_STEP_APP
-               ::step_count (count tasks)}))
+      (throw+ {:type       :clojure-commons.exception/illegal-argument
+               :error      :NOT_SINGLE_STEP_APP
+               :step_count (count tasks)}))
     (first tasks)))
 
 (defn- get-parameter-group-in-task

--- a/services/metadactyl-clj/src/metadactyl/persistence/jobs.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/jobs.clj
@@ -123,8 +123,8 @@
   [{:keys [job-id step-number external-id start-date end-date status job-type app-step-number]}]
   (let [job-type-id (kj/get-job-type-id job-type)]
     (when (nil? job-type-id)
-      (throw+ {:type   :clojure-commons.exception/missing-request-field
-               :error  "Job type id missing"
+      (throw+ {:type     :clojure-commons.exception/missing-request-field
+               :error    "Job type id missing"
                :job-type job-type}))
     (kj/save-job-step
       (remove-nil-values

--- a/services/metadactyl-clj/src/metadactyl/persistence/jobs.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/jobs.clj
@@ -9,8 +9,6 @@
   (:require [cheshire.core :as cheshire]
             [clojure.set :as set]
             [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
             [kameleon.jobs :as kj]
             [korma.core :as sql]))
 
@@ -125,8 +123,9 @@
   [{:keys [job-id step-number external-id start-date end-date status job-type app-step-number]}]
   (let [job-type-id (kj/get-job-type-id job-type)]
     (when (nil? job-type-id)
-      (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-               :job-type   job-type}))
+      (throw+ {:type   :clojure-commons.exception/missing-request-field
+               :error  "Job type id missing"
+               :job-type job-type}))
     (kj/save-job-step
       (remove-nil-values
         {:job_id          job-id

--- a/services/metadactyl-clj/src/metadactyl/persistence/oauth.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/oauth.clj
@@ -2,8 +2,7 @@
   "Functions to use for storing and retrieving OAuth access tokens."
   (:use [korma.core :exclude [update]]
         [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as ce]
-            [korma.core :as sql]
+  (:require [korma.core :as sql]
             [metadactyl.util.pgp :as pgp])
   (:import [java.sql Timestamp]
            [java.util UUID]))
@@ -12,8 +11,8 @@
   "Verifies that the token type is supported."
   [token-type]
   (when-not (= "bearer" token-type)
-    (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-             :reason     (str "OAuth 2.0 token type, " token-type ", is not supported.")})))
+    (throw+ {:type  :clojure-commons.exception/illegal-argument
+             :error (str "OAuth 2.0 token type, " token-type ", is not supported.")})))
 
 (defn- user-id-subselect
   "Returns a subselect statement to find a user ID."
@@ -117,10 +116,10 @@
   (let [id  (if (string? id) (UUID/fromString id) id)
         req (get-authorization-request id)]
     (when (nil? req)
-      (throw+ {:error_code ce/ERR_BAD_REQUEST
-               :reason     (str "authorization request " (str id) " not found")}))
+      (throw+ {:type  :clojure-commons.exception/not-found
+               :error (str "authorization request " (str id) " not found")}))
     (when (not= (:username req) username)
-      (throw+ {:error_code ce/ERR_BAD_REQUEST
-               :reason     (str "wrong user for authorization request " (str id))}))
+      (throw+ {:type  :clojure-commons.exception/bad-request-field
+               :error (str "wrong user for authorization request " (str id))}))
     (remove-prior-authorization-requests username)
     (:state-info req)))

--- a/services/metadactyl-clj/src/metadactyl/persistence/oauth.clj
+++ b/services/metadactyl-clj/src/metadactyl/persistence/oauth.clj
@@ -116,7 +116,7 @@
   (let [id  (if (string? id) (UUID/fromString id) id)
         req (get-authorization-request id)]
     (when (nil? req)
-      (throw+ {:type  :clojure-commons.exception/not-found
+      (throw+ {:type  :clojure-commons.exception/bad-request-field
                :error (str "authorization request " (str id) " not found")}))
     (when (not= (:username req) username)
       (throw+ {:type  :clojure-commons.exception/bad-request-field

--- a/services/metadactyl-clj/src/metadactyl/routes/admin.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/admin.clj
@@ -10,33 +10,32 @@
         [metadactyl.routes.domain.reference-genome]
         [metadactyl.routes.domain.tool]
         [metadactyl.routes.params]
-        [metadactyl.user :only [current-user]])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.service.apps :as apps]
+        [metadactyl.user :only [current-user]]
+        [metadactyl.util.coercions :only [coerce!]]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.service.apps :as apps]
             [metadactyl.util.config :as config]
-            [metadactyl.util.service :as service]
-            [compojure.route :as route])
-  (:import [java.util UUID]))
+            [metadactyl.util.service :as service]))
 
 (defroutes* admin-tool-requests
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params ToolRequestListingParams]
         :return ToolRequestListing
         :summary "List Tool Requests"
         :description "This endpoint lists high level details about tool requests that have been submitted.
         Administrators may use this endpoint to track tool requests for all users."
-        (service/trap uri list-tool-requests params))
+        (ok (list-tool-requests params)))
 
-  (GET* "/:request-id" [:as {uri :uri}]
+  (GET* "/:request-id" []
         :path-params [request-id :- ToolRequestIdParam]
         :query [params SecuredQueryParams]
         :return ToolRequestDetails
         :summary "Obtain Tool Request Details"
         :description "This service obtains detailed information about a tool request. This is the service
         that the DE support team uses to obtain the request details."
-        (service/trap uri get-tool-request request-id))
+        (ok (get-tool-request request-id)))
 
-  (POST* "/:request-id/status" [:as {uri :uri}]
+  (POST* "/:request-id/status" []
          :path-params [request-id :- ToolRequestIdParam]
          :query [params SecuredQueryParams]
          :body [body (describe ToolRequestStatusUpdate "A Tool Request status update.")]
@@ -44,35 +43,35 @@
          :summary "Update the Status of a Tool Request"
          :description "This endpoint is used by Discovery Environment administrators to update the status
          of a tool request."
-         (service/trap uri update-tool-request request-id (config/uid-domain) current-user body)))
+         (ok (update-tool-request request-id (config/uid-domain) current-user body))))
 
 (defroutes* admin-apps
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
          :query [params SecuredQueryParams]
          :body [body (describe AppCategorizationRequest "An App Categorization Request.")]
          :summary "Categorize Apps"
          :description "This endpoint is used by the Admin interface to add or move Apps to into multiple
          Categories."
-         (service/trap uri apps/categorize-apps current-user body))
+         (ok (apps/categorize-apps current-user body)))
 
-  (POST* "/shredder" [:as {uri :uri}]
+  (POST* "/shredder" []
          :query [params SecuredQueryParams]
          :body [body (describe AppDeletionRequest "List of App IDs to delete.")]
          :summary "Permanently Deleting Apps"
          :description "This service physically removes an App from the database, which allows
          administrators to completely remove Apps that are causing problems."
-         (service/trap uri apps/permanently-delete-apps current-user body))
+         (ok (apps/permanently-delete-apps current-user body)))
 
-  (DELETE* "/:app-id" [:as {uri :uri}]
+  (DELETE* "/:app-id" []
            :path-params [app-id :- AppIdPathParam]
            :query [params SecuredQueryParams]
            :summary "Logically Deleting an App"
            :description "An app can be marked as deleted in the DE without being completely removed from
            the database using this service. This endpoint is the same as the non-admin endpoint,
            except an error is not returned if the user does not own the App."
-           (service/trap uri apps/admin-delete-app current-user app-id))
+           (ok (apps/admin-delete-app current-user app-id)))
 
-  (PATCH* "/:app-id" [:as {uri :uri}]
+  (PATCH* "/:app-id" []
           :path-params [app-id :- AppIdPathParam]
           :query [params SecuredQueryParams]
           :body [body (describe AdminAppPatchRequest "The App to update.")]
@@ -84,10 +83,10 @@
           <b>Note</b>: Although this endpoint accepts all App Group and Parameter fields within the
           'groups' array, only their 'description', 'label', and 'display' (only in parameter
           arguments) fields will be processed and updated by this endpoint."
-          (service/coerced-trap uri AppDetails
+          (service/coerced-trap nil AppDetails
                                 apps/admin-update-app current-user (assoc body :id app-id)))
 
-  (PATCH* "/:app-id/documentation" [:as {uri :uri body :body}]
+  (PATCH* "/:app-id/documentation" [:as {body :body}]
           :path-params [app-id :- AppIdPathParam]
           :query [params SecuredQueryParams]
           :body [body (describe AppDocumentationRequest "The App Documentation Request.")]
@@ -95,7 +94,7 @@
           :summary "Update App Documentation"
           :description "This service is used by DE administrators to update documentation for a single
           App"
-          (service/coerced-trap uri AppDocumentation
+          (service/coerced-trap nil AppDocumentation
                                 apps/admin-edit-app-docs current-user app-id body))
 
   (POST* "/:app-id/documentation" [:as {uri :uri body :body}]
@@ -109,15 +108,15 @@
                                apps/admin-add-app-docs current-user app-id body)))
 
 (defroutes* admin-categories
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params CategoryListingParams]
         :return AppCategoryListing
         :summary "List App Categories"
         :description "This service is used by DE admins to obtain a list of public app categories along
         with the 'Trash' virtual category."
-        (service/trap uri apps/get-admin-app-categories current-user params))
+        (ok (apps/get-admin-app-categories current-user params)))
 
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
          :query [params SecuredQueryParams]
          :body [body (describe AppCategoryRequest "The details of the App Category to add.")]
          :return AppCategoryAppListing
@@ -125,9 +124,9 @@
          :description "This endpoint adds an App Category under the given parent App Category, as long as
          that parent Category doesn't already have a subcategory with the given name and it doesn't
          directly contain its own Apps."
-         (service/trap uri apps/admin-add-category current-user body))
+         (ok (apps/admin-add-category current-user body)))
 
-  (POST* "/shredder" [:as {uri :uri}]
+  (POST* "/shredder" []
          :query [params SecuredQueryParams]
          :body [body (describe AppCategoryIdList "A List of App Category IDs to delete.")]
          :return AppCategoryIdList
@@ -136,44 +135,44 @@
          subcategories will be deleted by this service, but no Apps will be removed. The response
          contains a list of Category IDs for which the deletion failed (including any subcategories
          of a Category already included in the request)."
-         (service/trap uri apps/admin-delete-categories current-user body))
+         (ok (apps/admin-delete-categories current-user body)))
 
-  (DELETE* "/:category-id" [:as {uri :uri}]
+  (DELETE* "/:category-id" []
            :path-params [category-id :- AppCategoryIdPathParam]
            :query [params SecuredQueryParams]
            :summary "Delete an App Category"
            :description "This service physically removes an App Category from the database, along with all
            of its child Categories, as long as none of them contain any Apps."
-           (service/trap uri apps/admin-delete-category current-user category-id))
+           (ok (apps/admin-delete-category current-user category-id)))
 
-  (PATCH* "/:category-id" [:as {uri :uri}]
+  (PATCH* "/:category-id" []
           :path-params [category-id :- AppCategoryIdPathParam]
           :query [params SecuredQueryParams]
           :body [body (describe AppCategoryPatchRequest "Details of the App Category to update.")]
           :summary "Update an App Category"
           :description "This service renames or moves an App Category to a new parent Category, depending
           on the fields included in the request."
-          (service/trap uri apps/admin-update-category current-user (assoc body :id category-id))))
+          (ok (apps/admin-update-category current-user (assoc body :id category-id)))))
 
 (defroutes* reference-genomes
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
          :query [params SecuredQueryParams]
          :body [body (describe ReferenceGenomeRequest "The Reference Genome to add.")]
          :return ReferenceGenome
          :summary "Add a Reference Genome."
          :description "This endpoint adds a Reference Genome to the Discovery Environment."
-         (ce/trap uri #(add-reference-genome body)))
+         (ok (add-reference-genome body)))
 
-  (PUT* "/" [:as {uri :uri}]
+  (PUT* "/" []
             :query [params SecuredQueryParams]
             :body [body (describe ReferenceGenomesSetRequest "List of Reference Genomes to set.")]
             :return ReferenceGenomesList
             :summary "Replace Reference Genomes."
             :description "This endpoint replaces ALL the Reference Genomes in the Discovery Environment,
             so if a genome is not listed in the request, it will not show up in the DE."
-            (ce/trap uri #(replace-reference-genomes body)))
+            (ok (replace-reference-genomes body)))
 
-  (PATCH* "/:reference-genome-id" [:as {uri :uri}]
+  (PATCH* "/:reference-genome-id" []
           :path-params [reference-genome-id :- ReferenceGenomeIdParam]
           :query [params SecuredQueryParams]
           :body [body (describe ReferenceGenomeRequest "The Reference Genome fields to update.")]
@@ -181,9 +180,9 @@
           :summary "Update a Reference Genome."
           :description "This endpoint modifies the name, path, and deleted fields of a Reference Genome in
           the Discovery Environment."
-          (ce/trap uri #(update-reference-genome (assoc body :id reference-genome-id))))
+          (ok (update-reference-genome (assoc body :id reference-genome-id))))
 
-  (DELETE* "/:reference-genome-id" [:as {uri :uri}]
+  (DELETE* "/:reference-genome-id" []
            :path-params [reference-genome-id :- ReferenceGenomeIdParam]
            :query [params SecuredQueryParams]
            :summary "Delete a Reference Genome."
@@ -192,4 +191,4 @@
            Reference Genome that is already marked as deleted is treated as a no-op rather than an
            error condition. If the Reference Genome doesn't exist in the database at all, however,
            then that is treated as an error condition."
-           (ce/trap uri #(delete-reference-genome reference-genome-id))))
+           (ok (delete-reference-genome reference-genome-id))))

--- a/services/metadactyl-clj/src/metadactyl/routes/admin.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/admin.clj
@@ -14,8 +14,7 @@
         [metadactyl.util.coercions :only [coerce!]]
         [ring.util.http-response :only [ok]])
   (:require [metadactyl.service.apps :as apps]
-            [metadactyl.util.config :as config]
-            [metadactyl.util.service :as service]))
+            [metadactyl.util.config :as config]))
 
 (defroutes* admin-tool-requests
   (GET* "/" []
@@ -83,10 +82,10 @@
           <b>Note</b>: Although this endpoint accepts all App Group and Parameter fields within the
           'groups' array, only their 'description', 'label', and 'display' (only in parameter
           arguments) fields will be processed and updated by this endpoint."
-          (service/coerced-trap nil AppDetails
-                                apps/admin-update-app current-user (assoc body :id app-id)))
+          (ok (coerce! AppDetails
+                (apps/admin-update-app current-user (assoc body :id app-id)))))
 
-  (PATCH* "/:app-id/documentation" [:as {body :body}]
+  (PATCH* "/:app-id/documentation" []
           :path-params [app-id :- AppIdPathParam]
           :query [params SecuredQueryParams]
           :body [body (describe AppDocumentationRequest "The App Documentation Request.")]
@@ -94,18 +93,18 @@
           :summary "Update App Documentation"
           :description "This service is used by DE administrators to update documentation for a single
           App"
-          (service/coerced-trap nil AppDocumentation
-                                apps/admin-edit-app-docs current-user app-id body))
+          (ok (coerce! AppDocumentation
+                (apps/admin-edit-app-docs current-user app-id body))))
 
-  (POST* "/:app-id/documentation" [:as {uri :uri body :body}]
+  (POST* "/:app-id/documentation" []
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParams]
          :body [body (describe AppDocumentationRequest "The App Documentation Request.")]
          :return AppDocumentation
          :summary "Add App Documentation"
          :description "This service is used by DE administrators to add documentation for a single App"
-         (service/coerced-trap uri AppDocumentation
-                               apps/admin-add-app-docs current-user app-id body)))
+         (ok (coerce! AppDocumentation
+                  (apps/admin-add-app-docs current-user app-id body)))))
 
 (defroutes* admin-categories
   (GET* "/" []

--- a/services/metadactyl-clj/src/metadactyl/routes/analyses.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/analyses.clj
@@ -4,9 +4,9 @@
         [metadactyl.routes.domain.analysis.listing]
         [metadactyl.routes.domain.app]
         [metadactyl.routes.params]
-        [metadactyl.user :only [current-user]])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.json :as json]
+        [metadactyl.user :only [current-user]]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.json :as json]
             [metadactyl.service.apps :as apps]
             [metadactyl.util.coercions :as coercions]
             [metadactyl.util.service :as service]))
@@ -45,35 +45,35 @@
           :return      AnalysisUpdateResponse
           :summary     "Update an Analysis"
           :description       "This service allows an analysis name or description to be updated."
-          (service/coerced-trap uri AnalysisUpdateResponse
+          (service/coerced-trap nil AnalysisUpdateResponse
                                 apps/update-job current-user analysis-id body))
 
-  (DELETE* "/:analysis-id" [:as {:keys [uri]}]
+  (DELETE* "/:analysis-id" []
            :path-params [analysis-id :- AnalysisIdPathParam]
            :query       [params SecuredQueryParams]
            :summary     "Delete an Analysis"
            :description       "This service marks an analysis as deleted in the DE database."
-           (service/trap uri apps/delete-job current-user analysis-id))
+           (ok (apps/delete-job current-user analysis-id)))
 
-  (POST* "/shredder" [:as {:keys [uri]}]
+  (POST* "/shredder" []
          :query   [params SecuredQueryParams]
          :body    [body AnalysisShredderRequest]
          :summary "Delete Multiple Analyses"
          :description   "This service allows the caller to mark one or more analyses as deleted
          in the apps database."
-         (service/trap uri apps/delete-jobs current-user body))
+         (ok (apps/delete-jobs current-user body)))
 
-  (GET* "/:analysis-id/parameters" [:as {:keys [uri]}]
+  (GET* "/:analysis-id/parameters" []
         :path-params [analysis-id :- AnalysisIdPathParam]
         :query       [params SecuredQueryParams]
         :return      AnalysisParameters
         :summary     "Display the parameters used in an analysis."
         :description       "This service returns a list of parameter values used in a previously
         executed analysis."
-        (service/coerced-trap uri AnalysisParameters
+        (service/coerced-trap nil AnalysisParameters
                               apps/get-parameter-values current-user analysis-id))
 
-  (GET* "/:analysis-id/relaunch-info" [:as {:keys [uri]}]
+  (GET* "/:analysis-id/relaunch-info" []
         :path-params [analysis-id :- AnalysisIdPathParam]
         :query       [params SecuredQueryParams]
         :return      AppJobView
@@ -81,21 +81,21 @@
         :description       "This service allows the Discovery Environment user interface to obtain an
         app description that can be used to relaunch a previously submitted job, possibly with
         modified parameter values."
-        (service/coerced-trap uri AppJobView
+        (service/coerced-trap nil AppJobView
                               apps/get-job-relaunch-info current-user analysis-id))
 
-  (POST* "/:analysis-id/stop" [:as {:keys [uri]}]
+  (POST* "/:analysis-id/stop" []
          :path-params [analysis-id :- AnalysisIdPathParam]
          :query       [params SecuredQueryParams]
          :return      StopAnalysisResponse
          :summary     "Stop a running analysis."
          :description       "This service allows DE users to stop running analyses."
-         (service/coerced-trap uri StopAnalysisResponse apps/stop-job current-user analysis-id))
+         (service/coerced-trap nil StopAnalysisResponse apps/stop-job current-user analysis-id))
 
-  (GET* "/:analysis-id/steps" [:as {:keys [uri]}]
+  (GET* "/:analysis-id/steps" []
         :path-params [analysis-id :- AnalysisIdPathParam]
         :query       [params SecuredQueryParams]
         :return      AnalysisStepList
         :summary     "Display the steps of an analysis."
         :description "This service returns a list of steps in an analysis."
-        (service/trap uri apps/list-job-steps current-user analysis-id)))
+        (ok (apps/list-job-steps current-user analysis-id))))

--- a/services/metadactyl-clj/src/metadactyl/routes/analyses.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/analyses.clj
@@ -5,14 +5,14 @@
         [metadactyl.routes.domain.app]
         [metadactyl.routes.params]
         [metadactyl.user :only [current-user]]
+        [metadactyl.util.coercions :only [coerce!]]
         [ring.util.http-response :only [ok]])
   (:require [metadactyl.json :as json]
             [metadactyl.service.apps :as apps]
-            [metadactyl.util.coercions :as coercions]
-            [metadactyl.util.service :as service]))
+            [metadactyl.util.coercions :as coercions]))
 
 (defroutes* analyses
-  (GET* "/" [:as {:keys [uri]}]
+  (GET* "/" []
         :query   [{:keys [filter] :as params} SecuredAnalysisListingParams]
         :return  AnalysisList
         :summary "List Analyses"
@@ -20,14 +20,13 @@
         for execution."
         ;; JSON query params are not currently supported by compojure-api,
         ;; so we have to decode the String filter param and validate it here.
-        (service/coerced-trap uri AnalysisList
-          apps/list-jobs
-          current-user
-          (coercions/coerce!
-            (assoc SecuredAnalysisListingParams OptionalKeyFilter [FilterParams])
-            (assoc params :filter (json/from-json filter)))))
+        (ok (coerce! AnalysisList
+                 (apps/list-jobs current-user
+                   (coercions/coerce!
+                     (assoc SecuredAnalysisListingParams OptionalKeyFilter [FilterParams])
+                     (assoc params :filter (json/from-json filter)))))))
 
-  (POST* "/" [:as {:keys [uri]}]
+  (POST* "/" []
          :query   [params SecuredQueryParamsEmailRequired]
          :body    [body AnalysisSubmission]
          :return  AnalysisResponse
@@ -36,17 +35,18 @@
          element in the analysis submission is a map from parameter IDs as they appear in
          the response from the `/apps/:app-id` endpoint to the desired values for those
          parameters."
-         (service/coerced-trap uri AnalysisResponse apps/submit-job current-user body))
+         (ok (coerce! AnalysisResponse
+                  (apps/submit-job current-user body))))
 
-  (PATCH* "/:analysis-id" [:as {:keys [uri]}]
+  (PATCH* "/:analysis-id" []
           :path-params [analysis-id :- AnalysisIdPathParam]
           :query       [params SecuredQueryParams]
           :body        [body AnalysisUpdate]
           :return      AnalysisUpdateResponse
           :summary     "Update an Analysis"
           :description       "This service allows an analysis name or description to be updated."
-          (service/coerced-trap nil AnalysisUpdateResponse
-                                apps/update-job current-user analysis-id body))
+          (ok (coerce! AnalysisUpdateResponse
+                   (apps/update-job current-user analysis-id body))))
 
   (DELETE* "/:analysis-id" []
            :path-params [analysis-id :- AnalysisIdPathParam]
@@ -70,8 +70,8 @@
         :summary     "Display the parameters used in an analysis."
         :description       "This service returns a list of parameter values used in a previously
         executed analysis."
-        (service/coerced-trap nil AnalysisParameters
-                              apps/get-parameter-values current-user analysis-id))
+        (ok (coerce! AnalysisParameters
+                 (apps/get-parameter-values current-user analysis-id))))
 
   (GET* "/:analysis-id/relaunch-info" []
         :path-params [analysis-id :- AnalysisIdPathParam]
@@ -81,8 +81,8 @@
         :description       "This service allows the Discovery Environment user interface to obtain an
         app description that can be used to relaunch a previously submitted job, possibly with
         modified parameter values."
-        (service/coerced-trap nil AppJobView
-                              apps/get-job-relaunch-info current-user analysis-id))
+        (ok (coerce! AppJobView
+                 (apps/get-job-relaunch-info current-user analysis-id))))
 
   (POST* "/:analysis-id/stop" []
          :path-params [analysis-id :- AnalysisIdPathParam]
@@ -90,7 +90,8 @@
          :return      StopAnalysisResponse
          :summary     "Stop a running analysis."
          :description       "This service allows DE users to stop running analyses."
-         (service/coerced-trap nil StopAnalysisResponse apps/stop-job current-user analysis-id))
+         (ok (coerce! StopAnalysisResponse
+                  (apps/stop-job current-user analysis-id))))
 
   (GET* "/:analysis-id/steps" []
         :path-params [analysis-id :- AnalysisIdPathParam]

--- a/services/metadactyl-clj/src/metadactyl/routes/apps.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps.clj
@@ -5,19 +5,20 @@
         [metadactyl.routes.domain.tool :only [NewToolListing]]
         [metadactyl.routes.params]
         [metadactyl.user :only [current-user]]
+        [metadactyl.util.coercions :only [coerce!]]
         [ring.util.http-response :only [ok]])
-  (:require [metadactyl.service.apps :as apps]
-            [metadactyl.util.service :as service]))
+  (:require [metadactyl.service.apps :as apps]))
 
 (defroutes* apps
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params AppSearchParams]
         :summary "Search Apps"
         :return AppListing
         :description "This service allows users to search for Apps based on a part of the App name or
         description. The response body contains an `apps` array that is in the same format as
         the `apps` array in the /apps/categories/:category-id endpoint response."
-        (service/coerced-trap uri AppListing apps/search-apps current-user params))
+        (ok (coerce! AppListing
+                 (apps/search-apps current-user params))))
 
   (POST* "/" []
          :query [params SecuredQueryParamsRequired]
@@ -58,14 +59,15 @@
          condition."
          (ok (apps/delete-apps current-user body)))
 
-  (GET* "/:app-id" [:as {uri :uri}]
+  (GET* "/:app-id" []
         :path-params [app-id :- AppIdJobViewPathParam]
         :query [params SecuredQueryParams]
         :summary "Obtain an app description."
         :return AppJobView
         :description "This service allows the Discovery Environment user interface to obtain an
         app description that can be used to construct a job submission form."
-        (service/coerced-trap uri AppJobView apps/get-app-job-view current-user app-id))
+        (ok (coerce! AppJobView
+                 (apps/get-app-job-view current-user app-id))))
 
   (DELETE* "/:app-id" []
            :path-params [app-id :- AppIdPathParam]
@@ -118,7 +120,8 @@
         :return AppDetails
         :summary "Get App Details"
         :description "This service is used by the DE to obtain high-level details about a single App"
-        (service/coerced-trap nil AppDetails apps/get-app-details current-user app-id))
+        (ok (coerce! AppDetails
+                 (apps/get-app-details current-user app-id))))
 
   (GET* "/:app-id/documentation" []
         :path-params [app-id :- AppIdJobViewPathParam]
@@ -126,27 +129,28 @@
         :return AppDocumentation
         :summary "Get App Documentation"
         :description "This service is used by the DE to obtain documentation for a single App"
-        (service/coerced-trap nil AppDocumentation apps/get-app-docs current-user app-id))
+        (ok (coerce! AppDocumentation
+                 (apps/get-app-docs current-user app-id))))
 
-  (PATCH* "/:app-id/documentation" [:as {body :body}]
+  (PATCH* "/:app-id/documentation" []
           :path-params [app-id :- AppIdPathParam]
           :query [params SecuredQueryParamsEmailRequired]
           :body [body (describe AppDocumentationRequest "The App Documentation Request.")]
           :return AppDocumentation
           :summary "Update App Documentation"
           :description "This service is used by the DE to update documentation for a single App"
-          (service/coerced-trap nil AppDocumentation
-                                apps/owner-edit-app-docs current-user app-id body))
+          (ok (coerce! AppDocumentation
+                   (apps/owner-edit-app-docs current-user app-id body))))
 
-  (POST* "/:app-id/documentation" [:as {body :body}]
+  (POST* "/:app-id/documentation" []
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParamsEmailRequired]
          :body [body (describe AppDocumentationRequest "The App Documentation Request.")]
          :return AppDocumentation
          :summary "Add App Documentation"
          :description "This service is used by the DE to add documentation for a single App"
-         (service/coerced-trap nil AppDocumentation
-                               apps/owner-add-app-docs current-user app-id body))
+         (ok (coerce! AppDocumentation
+                  (apps/owner-add-app-docs current-user app-id body))))
 
   (DELETE* "/:app-id/favorite" []
            :path-params [app-id :- AppIdPathParam]
@@ -215,7 +219,8 @@
         :description "When a pipeline is being created, the UI needs to know what types of files are
         consumed by and what types of files are produced by each App's task in the pipeline. This
         service provides that information."
-        (service/coerced-trap nil AppTaskListing apps/get-app-task-listing current-user app-id))
+        (ok (coerce! AppTaskListing
+                 (apps/get-app-task-listing current-user app-id))))
 
   (GET* "/:app-id/tools" []
         :path-params [app-id :- AppIdJobViewPathParam]
@@ -224,7 +229,8 @@
         :summary "List Tools used by an App"
         :description "This service lists information for all of the tools that are associated with an App.
         This information used to be included in the results of the App listing service."
-        (service/coerced-trap nil NewToolListing apps/get-app-tool-listing current-user app-id))
+        (ok (coerce! NewToolListing
+                 (apps/get-app-tool-listing current-user app-id))))
 
   (GET* "/:app-id/ui" []
         :path-params [app-id :- AppIdPathParam]

--- a/services/metadactyl-clj/src/metadactyl/routes/apps.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps.clj
@@ -4,9 +4,9 @@
         [metadactyl.routes.domain.app.rating]
         [metadactyl.routes.domain.tool :only [NewToolListing]]
         [metadactyl.routes.params]
-        [metadactyl.user :only [current-user]])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.service.apps :as apps]
+        [metadactyl.user :only [current-user]]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.service.apps :as apps]
             [metadactyl.util.service :as service]))
 
 (defroutes* apps
@@ -19,15 +19,15 @@
         the `apps` array in the /apps/categories/:category-id endpoint response."
         (service/coerced-trap uri AppListing apps/search-apps current-user params))
 
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
          :query [params SecuredQueryParamsRequired]
          :body [body (describe AppRequest "The App to add.")]
          :return App
          :summary "Add a new App."
          :description "This service adds a new App to the user's workspace."
-         (service/trap uri apps/add-app current-user body))
+         (ok (apps/add-app current-user body)))
 
-  (POST* "/arg-preview" [:as {uri :uri}]
+  (POST* "/arg-preview" []
          :query [params SecuredQueryParams]
          :body [body (describe AppPreviewRequest "The App to preview.")]
          :summary "Preview Command Line Arguments"
@@ -37,17 +37,17 @@
          body also requires that each parameter contain a `value` field that contains the parameter
          value to include on the command line. The response body is in the same format as the
          `/arg-preview` service in the JEX. Please see the JEX documentation for more information."
-         (service/trap uri apps/preview-command-line current-user body))
+         (ok (apps/preview-command-line current-user body)))
 
-  (GET* "/ids" [:as {uri :uri}]
+  (GET* "/ids" []
         :query [params SecuredQueryParams]
         :return AppIdList
         :summary "List All App Identifiers"
         :description "The export script needs to have a way to obtain the identifiers of all of the apps
         in the Discovery Environment, deleted or not. This service provides that information."
-        (service/trap uri apps/list-app-ids current-user))
+        (ok (apps/list-app-ids current-user)))
 
-  (POST* "/shredder" [:as {uri :uri}]
+  (POST* "/shredder" []
          :query [params SecuredQueryParams]
          :body [body (describe AppDeletionRequest "List of App IDs to delete.")]
          :summary "Logically Deleting Apps"
@@ -56,7 +56,7 @@
          is already marked as deleted is treated as a no-op rather than an error condition. If the
          App doesn't exist in the database at all, however, then that is treated as an error
          condition."
-         (service/trap uri apps/delete-apps current-user body))
+         (ok (apps/delete-apps current-user body)))
 
   (GET* "/:app-id" [:as {uri :uri}]
         :path-params [app-id :- AppIdJobViewPathParam]
@@ -67,7 +67,7 @@
         app description that can be used to construct a job submission form."
         (service/coerced-trap uri AppJobView apps/get-app-job-view current-user app-id))
 
-  (DELETE* "/:app-id" [:as {uri :uri}]
+  (DELETE* "/:app-id" []
            :path-params [app-id :- AppIdPathParam]
            :query [params SecuredQueryParams]
            :summary "Logically Deleting an App"
@@ -76,9 +76,9 @@
            marked as deleted is treated as a no-op rather than an error condition. If the App
            doesn't exist in the database at all, however, then that is treated as an error
            condition."
-           (service/trap uri apps/delete-app current-user app-id))
+           (ok (apps/delete-app current-user app-id)))
 
-  (PATCH* "/:app-id" [:as {uri :uri}]
+  (PATCH* "/:app-id" []
           :path-params [app-id :- AppIdPathParam]
           :query [params SecuredQueryParamsEmailRequired]
           :body [body (describe App "The App to update.")]
@@ -92,9 +92,9 @@
           only the 'name' (except in parameters and parameter arguments), 'description', 'label',
           and 'display' (only in parameter arguments) fields will be processed and updated by this
           endpoint."
-          (service/trap uri apps/relabel-app current-user (assoc body :id app-id)))
+          (ok (apps/relabel-app current-user (assoc body :id app-id))))
 
-  (PUT* "/:app-id" [:as {uri :uri}]
+  (PUT* "/:app-id" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParamsEmailRequired]
         :body [body (describe AppRequest "The App to update.")]
@@ -102,79 +102,79 @@
         :summary "Update an App"
         :description "This service updates a single-step App in the database, as long as the App has not
         been submitted for public use."
-        (service/trap uri apps/update-app current-user (assoc body :id app-id)))
+        (ok (apps/update-app current-user (assoc body :id app-id))))
 
-  (POST* "/:app-id/copy" [:as {uri :uri}]
+  (POST* "/:app-id/copy" []
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParamsRequired]
          :return App
          :summary "Make a Copy of an App Available for Editing"
          :description "This service can be used to make a copy of an App in the user's workspace."
-         (service/trap uri apps/copy-app current-user app-id))
+         (ok (apps/copy-app current-user app-id)))
 
-  (GET* "/:app-id/details" [:as {uri :uri}]
+  (GET* "/:app-id/details" []
         :path-params [app-id :- AppIdJobViewPathParam]
         :query [params SecuredQueryParams]
         :return AppDetails
         :summary "Get App Details"
         :description "This service is used by the DE to obtain high-level details about a single App"
-        (service/coerced-trap uri AppDetails apps/get-app-details current-user app-id))
+        (service/coerced-trap nil AppDetails apps/get-app-details current-user app-id))
 
-  (GET* "/:app-id/documentation" [:as {uri :uri}]
+  (GET* "/:app-id/documentation" []
         :path-params [app-id :- AppIdJobViewPathParam]
         :query [params SecuredQueryParams]
         :return AppDocumentation
         :summary "Get App Documentation"
         :description "This service is used by the DE to obtain documentation for a single App"
-        (service/coerced-trap uri AppDocumentation apps/get-app-docs current-user app-id))
+        (service/coerced-trap nil AppDocumentation apps/get-app-docs current-user app-id))
 
-  (PATCH* "/:app-id/documentation" [:as {uri :uri body :body}]
+  (PATCH* "/:app-id/documentation" [:as {body :body}]
           :path-params [app-id :- AppIdPathParam]
           :query [params SecuredQueryParamsEmailRequired]
           :body [body (describe AppDocumentationRequest "The App Documentation Request.")]
           :return AppDocumentation
           :summary "Update App Documentation"
           :description "This service is used by the DE to update documentation for a single App"
-          (service/coerced-trap uri AppDocumentation
+          (service/coerced-trap nil AppDocumentation
                                 apps/owner-edit-app-docs current-user app-id body))
 
-  (POST* "/:app-id/documentation" [:as {uri :uri body :body}]
+  (POST* "/:app-id/documentation" [:as {body :body}]
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParamsEmailRequired]
          :body [body (describe AppDocumentationRequest "The App Documentation Request.")]
          :return AppDocumentation
          :summary "Add App Documentation"
          :description "This service is used by the DE to add documentation for a single App"
-         (service/coerced-trap uri AppDocumentation
+         (service/coerced-trap nil AppDocumentation
                                apps/owner-add-app-docs current-user app-id body))
 
-  (DELETE* "/:app-id/favorite" [:as {uri :uri}]
+  (DELETE* "/:app-id/favorite" []
            :path-params [app-id :- AppIdPathParam]
            :query [params SecuredQueryParams]
            :summary "Removing an App as a Favorite"
            :description "Apps can be marked as favorites in the DE, which allows users to access them
            without having to search. This service is used to remove an App from a user's favorites
            list."
-           (service/trap uri apps/remove-app-favorite current-user app-id))
+           (ok (apps/remove-app-favorite current-user app-id)))
 
-  (PUT* "/:app-id/favorite" [:as {uri :uri}]
+  (PUT* "/:app-id/favorite" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
         :summary "Marking an App as a Favorite"
         :description "Apps can be marked as favorites in the DE, which allows users to access them without
         having to search. This service is used to add an App to a user's favorites list."
-        (service/trap uri apps/add-app-favorite current-user app-id))
+        (ok (apps/add-app-favorite current-user app-id)))
 
-  (GET* "/:app-id/is-publishable" [:as {uri :uri}]
+  (GET* "/:app-id/is-publishable" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
         :summary "Determine if an App Can be Made Public"
         :description "A multi-step App can't be made public if any of the Tasks that are included in it
         are not public. This endpoint returns a true flag if the App is a single-step App or it's a
         multistep App in which all of the Tasks included in the pipeline are public."
-        (service/trap uri apps/app-publishable? current-user app-id))
+        (ok (apps/app-publishable? current-user app-id)))
 
-  (POST* "/:app-id/publish" [:as {uri :uri}]
+  (POST* "/:app-id/publish" []
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParamsEmailRequired]
          :body [body (describe PublishAppRequest "The user's Publish App Request.")]
@@ -184,18 +184,18 @@
          information and suggested location then places the App in the Beta category. A Tito
          administrator can subsequently move the App to the suggested location at a later time if it
          proves to be useful."
-         (service/trap uri apps/make-app-public current-user (assoc body :id app-id)))
+         (ok (apps/make-app-public current-user (assoc body :id app-id))))
 
-  (DELETE* "/:app-id/rating" [:as {uri :uri}]
+  (DELETE* "/:app-id/rating" []
            :path-params [app-id :- AppIdPathParam]
            :query [params SecuredQueryParams]
            :return RatingResponse
            :summary "Delete an App Rating"
            :description "The DE uses this service to remove a rating that a user has previously made. This
            service deletes the authenticated user's rating for the corresponding app-id."
-           (service/trap uri apps/delete-app-rating current-user app-id))
+           (ok (apps/delete-app-rating current-user app-id)))
 
-  (POST* "/:app-id/rating" [:as {uri :uri}]
+  (POST* "/:app-id/rating" []
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParams]
          :body [body (describe RatingRequest "The user's new rating for this App.")]
@@ -205,9 +205,9 @@
          the means to store the App rating. This service accepts a rating level between one and
          five, inclusive, and a comment identifier that refers to a comment in iPlant's Confluence
          wiki. The rating is stored in the database and associated with the authenticated user."
-         (service/trap uri apps/rate-app current-user app-id body))
+         (ok (apps/rate-app current-user app-id body)))
 
-  (GET* "/:app-id/tasks" [:as {uri :uri}]
+  (GET* "/:app-id/tasks" []
         :path-params [app-id :- AppIdJobViewPathParam]
         :query [params SecuredQueryParams]
         :return AppTaskListing
@@ -215,18 +215,18 @@
         :description "When a pipeline is being created, the UI needs to know what types of files are
         consumed by and what types of files are produced by each App's task in the pipeline. This
         service provides that information."
-        (service/coerced-trap uri AppTaskListing apps/get-app-task-listing current-user app-id))
+        (service/coerced-trap nil AppTaskListing apps/get-app-task-listing current-user app-id))
 
-  (GET* "/:app-id/tools" [:as {uri :uri}]
+  (GET* "/:app-id/tools" []
         :path-params [app-id :- AppIdJobViewPathParam]
         :query [params SecuredQueryParams]
         :return NewToolListing
         :summary "List Tools used by an App"
         :description "This service lists information for all of the tools that are associated with an App.
         This information used to be included in the results of the App listing service."
-        (service/coerced-trap uri NewToolListing apps/get-app-tool-listing current-user app-id))
+        (service/coerced-trap nil NewToolListing apps/get-app-tool-listing current-user app-id))
 
-  (GET* "/:app-id/ui" [:as {uri :uri}]
+  (GET* "/:app-id/ui" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParamsEmailRequired]
         :return App
@@ -234,4 +234,4 @@
         :description "The app integration utility in the DE uses this service to obtain the App
         description JSON so that it can be edited. The App must have been integrated by the
         requesting user."
-        (service/trap uri apps/get-app-ui current-user app-id)))
+        (ok (apps/get-app-ui current-user app-id))))

--- a/services/metadactyl-clj/src/metadactyl/routes/apps/categories.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps/categories.clj
@@ -2,23 +2,22 @@
   (:use [common-swagger-api.schema]
         [metadactyl.routes.domain.app.category]
         [metadactyl.routes.params]
-        [metadactyl.user :only [current-user]])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.service.apps :as apps]
-            [metadactyl.util.coercions :as mc]
+        [metadactyl.user :only [current-user]]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.service.apps :as apps]
             [metadactyl.util.service :as service]
             [compojure.route :as route]))
 
 (defroutes* app-categories
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params CategoryListingParams]
         :return AppCategoryListing
         :summary "List App Categories"
         :description "This service is used by the DE to obtain the list of app categories that
          are visible to the user."
-        (service/trap uri apps/get-app-categories current-user params))
+        (ok (apps/get-app-categories current-user params)))
 
-  (GET* "/:category-id" [:as {uri :uri}]
+  (GET* "/:category-id" []
         :path-params [category-id :- AppCategoryIdPathParam]
         :query [params AppListingPagingParams]
         :return AppCategoryAppListing
@@ -28,7 +27,7 @@
          clicks on a category in the _Apps_ window.
          This endpoint accepts optional URL query parameters to limit and sort Apps,
          which will allow pagination of results."
-        (service/coerced-trap uri AppCategoryAppListing apps/list-apps-in-category current-user
+        (service/coerced-trap nil AppCategoryAppListing apps/list-apps-in-category current-user
                               category-id params))
 
   (route/not-found (service/unrecognized-path-response)))

--- a/services/metadactyl-clj/src/metadactyl/routes/apps/categories.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps/categories.clj
@@ -3,6 +3,7 @@
         [metadactyl.routes.domain.app.category]
         [metadactyl.routes.params]
         [metadactyl.user :only [current-user]]
+        [metadactyl.util.coercions :only [coerce!]]
         [ring.util.http-response :only [ok]])
   (:require [metadactyl.service.apps :as apps]
             [metadactyl.util.service :as service]
@@ -27,7 +28,7 @@
          clicks on a category in the _Apps_ window.
          This endpoint accepts optional URL query parameters to limit and sort Apps,
          which will allow pagination of results."
-        (service/coerced-trap nil AppCategoryAppListing apps/list-apps-in-category current-user
-                              category-id params))
+        (ok (coerce! AppCategoryAppListing
+                 (apps/list-apps-in-category current-user category-id params))))
 
   (route/not-found (service/unrecognized-path-response)))

--- a/services/metadactyl-clj/src/metadactyl/routes/apps/elements.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps/elements.clj
@@ -1,12 +1,12 @@
 (ns metadactyl.routes.apps.elements
-      (:use [common-swagger-api.schema]
-            [metadactyl.metadata.element-listings :only [list-elements]]
-            [metadactyl.routes.domain.app.element]
-            [metadactyl.routes.domain.tool :only [ToolListing]]
-            [metadactyl.routes.params]
-            [ring.util.http-response :only [ok]])
-      (:require [metadactyl.util.service :as service]
-                [compojure.route :as route]))
+  (:use [common-swagger-api.schema]
+        [metadactyl.metadata.element-listings :only [list-elements]]
+        [metadactyl.routes.domain.app.element]
+        [metadactyl.routes.domain.tool :only [ToolListing]]
+        [metadactyl.routes.params]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.util.service :as service]
+            [compojure.route :as route]))
 
 (defroutes* app-elements
   (GET* "/" []
@@ -14,7 +14,7 @@
         :summary "List All Available App Elements"
         :description "This endpoint may be used to obtain lists of all available elements that may be
         included in an App."
-        (ok (#(list-elements "all" params))))
+        (ok (list-elements "all" params)))
 
   (GET* "/data-sources" []
         :query [params SecuredQueryParams]
@@ -24,7 +24,7 @@
         parameters will come from a plain file. The only other options that are currently available
         are redirected standard output and redirected standard error output. Both of these options
         apply only to file parameters that are associated with an output."
-        (ok (#(list-elements "data-sources" params))))
+        (ok (list-elements "data-sources" params)))
 
   (GET* "/file-formats" []
         :query [params SecuredQueryParams]
@@ -33,7 +33,7 @@
         :description "The known file formats can be used to describe supported input or output formats for
         a tool. For example, tools in the FASTX toolkit may support FASTA files, several different
         varieties of FASTQ files and Barcode files, among others."
-        (ok (#(list-elements "file-formats" params))))
+        (ok (list-elements "file-formats" params)))
 
   (GET* "/info-types" []
         :query [params SecuredQueryParams]
@@ -47,7 +47,7 @@
         PhyloXML format, and a large number of other formats. The file format and information type
         together identify the type of input consumed by a tool or the type of output produced by a
         tool."
-        (ok (#(list-elements "info-types" params))))
+        (ok (list-elements "info-types" params)))
 
   (GET* "/parameter-types" []
         :query [params AppParameterTypeParams]
@@ -63,7 +63,7 @@
         (which is used to determine the tool type). If you filter by both tool type and tool ID then
         the tool type will take precedence. Including either an undefined tool type or an undefined
         tool type name will result in an error"
-        (ok (#(list-elements "parameter-types" params))))
+        (ok (list-elements "parameter-types" params)))
 
   (GET* "/rule-types" []
         :query [params SecuredQueryParams]
@@ -73,7 +73,7 @@
         input. For example, if a parameter value must be an integer between 1 and 10 then the
         `IntRange` rule type may be used. Similarly, if a parameter value must contain data in a
         specific format, such as a phone number, then the `Regex` rule type may be used."
-        (ok (#(list-elements "rule-types" params))))
+        (ok (list-elements "rule-types" params)))
 
   (GET* "/tools" []
         :query [params SecuredIncludeHiddenParams]
@@ -81,7 +81,7 @@
         :summary "List App Tools"
         :description "This endpoint is used by the Discovery Environment to obtain a list of registered
         tools (usually, command-line tools) that can be executed from within the DE."
-        (ok (#(list-elements "tools" params))))
+        (ok (list-elements "tools" params)))
 
   (GET* "/tool-types" []
         :query [params SecuredQueryParams]
@@ -89,7 +89,7 @@
         :summary "List App Tool Types"
         :description "Tool types are known types of tools in the Discovery Environment. Generally, there's
         a different tool type for each execution environment that is supported by the DE."
-        (ok (#(list-elements "tool-types" params))))
+        (ok (list-elements "tool-types" params)))
 
   (GET* "/value-types" []
         :query [params SecuredQueryParams]
@@ -101,6 +101,6 @@
         types is specifically to link parameter types and rule types. The App Editor uses the value
         type to determine which types of rules can be applied to a parameter that is being defined
         by the user."
-        (ok (#(list-elements "value-types" params))))
+        (ok (list-elements "value-types" params)))
 
   (route/not-found (service/unrecognized-path-response)))

--- a/services/metadactyl-clj/src/metadactyl/routes/apps/elements.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps/elements.clj
@@ -1,22 +1,22 @@
 (ns metadactyl.routes.apps.elements
-  (:use [common-swagger-api.schema]
-        [metadactyl.metadata.element-listings :only [list-elements]]
-        [metadactyl.routes.domain.app.element]
-        [metadactyl.routes.domain.tool :only [ToolListing]]
-        [metadactyl.routes.params])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.util.service :as service]
-            [compojure.route :as route]))
+      (:use [common-swagger-api.schema]
+            [metadactyl.metadata.element-listings :only [list-elements]]
+            [metadactyl.routes.domain.app.element]
+            [metadactyl.routes.domain.tool :only [ToolListing]]
+            [metadactyl.routes.params]
+            [ring.util.http-response :only [ok]])
+      (:require [metadactyl.util.service :as service]
+                [compojure.route :as route]))
 
 (defroutes* app-elements
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params SecuredIncludeHiddenParams]
         :summary "List All Available App Elements"
         :description "This endpoint may be used to obtain lists of all available elements that may be
         included in an App."
-        (ce/trap uri #(list-elements "all" params)))
+        (ok (#(list-elements "all" params))))
 
-  (GET* "/data-sources" [:as {uri :uri}]
+  (GET* "/data-sources" []
         :query [params SecuredQueryParams]
         :return DataSourceListing
         :summary "List App File Parameter Data Sources"
@@ -24,18 +24,18 @@
         parameters will come from a plain file. The only other options that are currently available
         are redirected standard output and redirected standard error output. Both of these options
         apply only to file parameters that are associated with an output."
-        (ce/trap uri #(list-elements "data-sources" params)))
+        (ok (#(list-elements "data-sources" params))))
 
-  (GET* "/file-formats" [:as {uri :uri}]
+  (GET* "/file-formats" []
         :query [params SecuredQueryParams]
         :return FileFormatListing
         :summary "List App Parameter File Formats"
         :description "The known file formats can be used to describe supported input or output formats for
         a tool. For example, tools in the FASTX toolkit may support FASTA files, several different
         varieties of FASTQ files and Barcode files, among others."
-        (ce/trap uri #(list-elements "file-formats" params)))
+        (ok (#(list-elements "file-formats" params))))
 
-  (GET* "/info-types" [:as {uri :uri}]
+  (GET* "/info-types" []
         :query [params SecuredQueryParams]
         :return InfoTypeListing
         :summary "List Tool Info Types"
@@ -47,9 +47,9 @@
         PhyloXML format, and a large number of other formats. The file format and information type
         together identify the type of input consumed by a tool or the type of output produced by a
         tool."
-        (ce/trap uri #(list-elements "info-types" params)))
+        (ok (#(list-elements "info-types" params))))
 
-  (GET* "/parameter-types" [:as {uri :uri}]
+  (GET* "/parameter-types" []
         :query [params AppParameterTypeParams]
         :return ParameterTypeListing
         :summary "List App Parameter Types"
@@ -63,9 +63,9 @@
         (which is used to determine the tool type). If you filter by both tool type and tool ID then
         the tool type will take precedence. Including either an undefined tool type or an undefined
         tool type name will result in an error"
-        (ce/trap uri #(list-elements "parameter-types" params)))
+        (ok (#(list-elements "parameter-types" params))))
 
-  (GET* "/rule-types" [:as {uri :uri}]
+  (GET* "/rule-types" []
         :query [params SecuredQueryParams]
         :return RuleTypeListing
         :summary "List App Parameter Rule Types"
@@ -73,25 +73,25 @@
         input. For example, if a parameter value must be an integer between 1 and 10 then the
         `IntRange` rule type may be used. Similarly, if a parameter value must contain data in a
         specific format, such as a phone number, then the `Regex` rule type may be used."
-        (ce/trap uri #(list-elements "rule-types" params)))
+        (ok (#(list-elements "rule-types" params))))
 
-  (GET* "/tools" [:as {uri :uri}]
+  (GET* "/tools" []
         :query [params SecuredIncludeHiddenParams]
         :return ToolListing
         :summary "List App Tools"
         :description "This endpoint is used by the Discovery Environment to obtain a list of registered
         tools (usually, command-line tools) that can be executed from within the DE."
-        (ce/trap uri #(list-elements "tools" params)))
+        (ok (#(list-elements "tools" params))))
 
-  (GET* "/tool-types" [:as {uri :uri}]
+  (GET* "/tool-types" []
         :query [params SecuredQueryParams]
         :return ToolTypeListing
         :summary "List App Tool Types"
         :description "Tool types are known types of tools in the Discovery Environment. Generally, there's
         a different tool type for each execution environment that is supported by the DE."
-        (ce/trap uri #(list-elements "tool-types" params)))
+        (ok (#(list-elements "tool-types" params))))
 
-  (GET* "/value-types" [:as {uri :uri}]
+  (GET* "/value-types" []
         :query [params SecuredQueryParams]
         :return ValueTypeListing
         :summary "List App Parameter and Rule Value Types"
@@ -101,6 +101,6 @@
         types is specifically to link parameter types and rule types. The App Editor uses the value
         type to determine which types of rules can be applied to a parameter that is being defined
         by the user."
-        (ce/trap uri #(list-elements "value-types" params)))
+        (ok (#(list-elements "value-types" params))))
 
   (route/not-found (service/unrecognized-path-response)))

--- a/services/metadactyl-clj/src/metadactyl/routes/apps/pipelines.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps/pipelines.clj
@@ -3,22 +3,19 @@
         [metadactyl.routes.domain.pipeline]
         [metadactyl.routes.params]
         [metadactyl.user :only [current-user]])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.service.apps :as apps]
-            [metadactyl.util.service :as service]
-            [ring.swagger.schema :as ss]
-            [schema.core :as s]))
+  (:require [metadactyl.service.apps :as apps]
+            [metadactyl.util.service :as service]))
 
 (defroutes* pipelines
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
          :query [params SecuredQueryParamsRequired]
          :body [body (describe PipelineCreateRequest "The Pipeline to create.")]
          :return Pipeline
          :summary "Create a Pipeline"
          :description "This service adds a new Pipeline."
-         (service/coerced-trap uri Pipeline apps/add-pipeline current-user body))
+         (service/coerced-trap nil Pipeline apps/add-pipeline current-user body))
 
-  (PUT* "/:app-id" [:as {uri :uri}]
+  (PUT* "/:app-id" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParamsEmailRequired]
         :body [body (describe PipelineUpdateRequest "The Pipeline to update.")]
@@ -26,10 +23,10 @@
         :summary "Update a Pipeline"
         :description "This service updates an existing Pipeline in the database, as long as the Pipeline
         has not been submitted for public use."
-        (service/coerced-trap uri Pipeline apps/update-pipeline current-user
+        (service/coerced-trap nil Pipeline apps/update-pipeline current-user
                               (assoc body :id app-id)))
 
-  (POST* "/:app-id/copy" [:as {uri :uri}]
+  (POST* "/:app-id/copy" []
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParamsRequired]
          :return Pipeline
@@ -37,9 +34,9 @@
          :description "This service can be used to make a copy of a Pipeline in the user's workspace. This
          endpoint will copy the App details, steps, and mappings, but will not copy tasks used in
          the Pipeline steps."
-         (service/coerced-trap uri Pipeline apps/copy-pipeline current-user app-id))
+         (service/coerced-trap nil Pipeline apps/copy-pipeline current-user app-id))
 
-  (GET* "/:app-id/ui" [:as {uri :uri}]
+  (GET* "/:app-id/ui" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParamsEmailRequired]
         :return Pipeline
@@ -47,4 +44,4 @@
         :description "The DE uses this service to obtain a JSON representation of a Pipeline for editing.
         The Pipeline must have been integrated by the requesting user, and it must not already be
         public."
-        (service/coerced-trap uri Pipeline apps/edit-pipeline current-user app-id)))
+        (service/coerced-trap nil Pipeline apps/edit-pipeline current-user app-id)))

--- a/services/metadactyl-clj/src/metadactyl/routes/apps/pipelines.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/apps/pipelines.clj
@@ -2,9 +2,10 @@
   (:use [common-swagger-api.schema]
         [metadactyl.routes.domain.pipeline]
         [metadactyl.routes.params]
+        [metadactyl.util.coercions :only [coerce!]]
+        [ring.util.http-response :only [ok]]
         [metadactyl.user :only [current-user]])
-  (:require [metadactyl.service.apps :as apps]
-            [metadactyl.util.service :as service]))
+  (:require [metadactyl.service.apps :as apps]))
 
 (defroutes* pipelines
   (POST* "/" []
@@ -13,7 +14,8 @@
          :return Pipeline
          :summary "Create a Pipeline"
          :description "This service adds a new Pipeline."
-         (service/coerced-trap nil Pipeline apps/add-pipeline current-user body))
+         (ok (coerce! Pipeline
+                  (apps/add-pipeline current-user body))))
 
   (PUT* "/:app-id" []
         :path-params [app-id :- AppIdPathParam]
@@ -23,8 +25,8 @@
         :summary "Update a Pipeline"
         :description "This service updates an existing Pipeline in the database, as long as the Pipeline
         has not been submitted for public use."
-        (service/coerced-trap nil Pipeline apps/update-pipeline current-user
-                              (assoc body :id app-id)))
+        (ok (coerce! Pipeline
+                 (apps/update-pipeline current-user (assoc body :id app-id)))))
 
   (POST* "/:app-id/copy" []
          :path-params [app-id :- AppIdPathParam]
@@ -34,7 +36,8 @@
          :description "This service can be used to make a copy of a Pipeline in the user's workspace. This
          endpoint will copy the App details, steps, and mappings, but will not copy tasks used in
          the Pipeline steps."
-         (service/coerced-trap nil Pipeline apps/copy-pipeline current-user app-id))
+         (ok (coerce! Pipeline
+                  (apps/copy-pipeline current-user app-id))))
 
   (GET* "/:app-id/ui" []
         :path-params [app-id :- AppIdPathParam]
@@ -44,4 +47,5 @@
         :description "The DE uses this service to obtain a JSON representation of a Pipeline for editing.
         The Pipeline must have been integrated by the requesting user, and it must not already be
         public."
-        (service/coerced-trap nil Pipeline apps/edit-pipeline current-user app-id)))
+        (ok (coerce! Pipeline
+                 (apps/edit-pipeline current-user app-id)))))

--- a/services/metadactyl-clj/src/metadactyl/routes/callbacks.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/callbacks.clj
@@ -1,22 +1,21 @@
 (ns metadactyl.routes.callbacks
   (:use [common-swagger-api.schema]
         [metadactyl.routes.domain.callback]
-        [metadactyl.routes.params])
-  (:require [compojure.core :as route]
-            [metadactyl.service.callbacks :as callbacks]
-            [metadactyl.util.service :as service]))
+        [metadactyl.routes.params]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.service.callbacks :as callbacks]))
 
 (defroutes* callbacks
-  (POST* "/de-job" [:as {:keys [uri]}]
+  (POST* "/de-job" []
          :body [body (describe DeJobStatusUpdate "The App to add.")]
          :summary "Update the status of of a DE analysis."
          :description "The jex-events service calls this endpoint when the status of a DE analysis
          changes"
-         (service/trap uri callbacks/update-de-job-status body))
+         (ok (callbacks/update-de-job-status body)))
 
-  (POST* "/agave-job/:job-id" [:as {:keys [uri]}]
+  (POST* "/agave-job/:job-id" []
          :path-params [job-id :- AnalysisIdPathParam]
          :query [params AgaveJobStatusUpdate]
          :summary "Update the status of an Agave analysis."
          :description "The DE registers this endpoint as a callback when it submts jobs to Agave."
-         (service/trap uri callbacks/update-agave-job-status job-id params)))
+         (ok (callbacks/update-agave-job-status job-id params))))

--- a/services/metadactyl-clj/src/metadactyl/routes/collaborators.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/collaborators.clj
@@ -2,29 +2,29 @@
   (:use [common-swagger-api.schema]
         [metadactyl.routes.domain.collaborator]
         [metadactyl.routes.params]
-        [metadactyl.user :only [current-user]])
-  (:require [metadactyl.service.collaborators :as collaborators]
-            [metadactyl.util.service :as service]))
+        [metadactyl.user :only [current-user]]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.service.collaborators :as collaborators]))
 
 (defroutes* collaborators
-  (GET* "/" [:as {:keys [uri]}]
+  (GET* "/" []
         :query [params SecuredQueryParams]
         :summary "List Collaborators"
         :return Collaborators
         :description "This service allows users to retrieve a list of their collaborators."
-        (service/trap uri collaborators/get-collaborators current-user))
+        (ok (collaborators/get-collaborators current-user)))
 
-  (POST* "/" [:as {:keys [uri]}]
+  (POST* "/" []
          :query [params SecuredQueryParams]
          :summary "Add Collaborators"
          :body [body (describe Collaborators "The collaborators to add.")]
          :description "This service allows users to add other users to their list of collaborators."
-         (service/trap uri collaborators/add-collaborators current-user body))
+         (ok (collaborators/add-collaborators current-user body)))
 
-  (POST* "/shredder" [:as {:keys [uri]}]
+  (POST* "/shredder" []
          :query [params SecuredQueryParams]
          :summary "Remove Collaborators"
          :body [body (describe Collaborators "The collaborators to remove.")]
          :description "This service allows users to remove other users from their list of
          collaborators."
-         (service/trap uri collaborators/remove-collaborators current-user body)))
+         (ok (collaborators/remove-collaborators current-user body))))

--- a/services/metadactyl-clj/src/metadactyl/routes/domain/callback.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/domain/callback.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.routes.domain.callback
   (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema optional-key]])
-  (:import [java.util UUID]))
+        [schema.core :only [defschema optional-key]]))
 
 (defschema DeJobState
   {:status

--- a/services/metadactyl-clj/src/metadactyl/routes/domain/collaborator.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/domain/collaborator.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.routes.domain.collaborator
   (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema optional-key]])
-  (:import [java.util UUID Date]))
+        [schema.core :only [defschema optional-key]]))
 
 (defschema Collaborator
   {(optional-key :id)          (describe String "The collaborator's ID in Trellis")

--- a/services/metadactyl-clj/src/metadactyl/routes/domain/user.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/domain/user.clj
@@ -2,7 +2,7 @@
   (:use [common-swagger-api.schema :only [describe]]
         [metadactyl.routes.params :only [SecuredQueryParams]]
         [schema.core :only [defschema]])
-  (:import [java.util Date UUID]))
+  (:import [java.util UUID]))
 
 (defschema User
   {:id       (describe UUID "The DE's internal user identifier")

--- a/services/metadactyl-clj/src/metadactyl/routes/oauth.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/oauth.clj
@@ -1,15 +1,14 @@
 (ns metadactyl.routes.oauth
   (:use [common-swagger-api.schema]
         [metadactyl.routes.domain.oauth]
-        [metadactyl.routes.params])
-  (require [clojure-commons.error-codes :as ce]
-           [metadactyl.service.oauth :as oauth]
-           [metadactyl.util.service :as service]))
+        [metadactyl.routes.params]
+        [ring.util.http-response :only [ok]])
+  (require [metadactyl.service.oauth :as oauth]))
 
 (defroutes* oauth
-  (GET* "/access-code/:api-name" [:as {uri :uri}]
+  (GET* "/access-code/:api-name" []
         :path-params [api-name :- ApiName]
         :query       [params OAuthCallbackQueryParams]
         :return      OAuthCallbackResponse
         :summary     "Obtain an OAuth access token for an authorization code."
-        (ce/trap uri #(oauth/get-access-token api-name params))))
+        (ok (oauth/get-access-token api-name params))))

--- a/services/metadactyl-clj/src/metadactyl/routes/reference_genomes.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/reference_genomes.clj
@@ -2,21 +2,21 @@
   (:use [common-swagger-api.schema]
         [metadactyl.metadata.reference-genomes :only [get-reference-genome list-reference-genomes]]
         [metadactyl.routes.domain.reference-genome]
-        [metadactyl.routes.params])
-  (:require [clojure-commons.error-codes :as ce]))
+        [metadactyl.routes.params]
+        [ring.util.http-response :only [ok]]))
 
 (defroutes* reference-genomes
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params ReferenceGenomeListingParams]
         :return ReferenceGenomesList
         :summary "List Reference Genomes."
         :description "This endpoint may be used to obtain lists of all available Reference Genomes."
-        (ce/trap uri #(list-reference-genomes params)))
+        (ok (list-reference-genomes params)))
 
-  (GET* "/:reference-genome-id" [:as {uri :uri}]
+  (GET* "/:reference-genome-id" []
         :path-params [reference-genome-id :- ReferenceGenomeIdParam]
         :query [params SecuredQueryParams]
         :return ReferenceGenome
         :summary "Get a Reference Genome."
         :description "This endpoint may be used to obtain a Reference Genome by its UUID."
-        (ce/trap uri #(get-reference-genome reference-genome-id))))
+        (ok (get-reference-genome reference-genome-id))))

--- a/services/metadactyl-clj/src/metadactyl/routes/status.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/status.clj
@@ -1,14 +1,14 @@
 (ns metadactyl.routes.status
   (:use [common-swagger-api.schema]
-        [metadactyl.routes.domain.status])
+        [metadactyl.routes.domain.status]
+        [ring.util.http-response :only [ok]])
   (:require [clojure-commons.service :as commons-service]
-            [metadactyl.util.config :as config]
-            [metadactyl.util.service :as service]))
+            [metadactyl.util.config :as config]))
 
 (defroutes* status
-  (GET* "/" [:as {:keys [uri server-name server-port]}]
+  (GET* "/" [:as {:keys [server-name server-port]}]
     :return StatusResponse
     :summary "Service Information"
     :description "This endpoint provides the name of the service and its version."
-    (service/trap uri
-      commons-service/get-docs-status config/svc-info server-name server-port config/docs-uri)))
+    (ok
+      (commons-service/get-docs-status config/svc-info server-name server-port config/docs-uri))))

--- a/services/metadactyl-clj/src/metadactyl/routes/tools.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/tools.clj
@@ -6,10 +6,10 @@
         [metadactyl.routes.domain.tool]
         [metadactyl.routes.params]
         [metadactyl.tools :only [add-tools get-tool search-tools update-tool]]
-        [metadactyl.user :only [current-user]])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.util.service :as service]
-            [compojure.route :as route]))
+        [metadactyl.user :only [current-user]]
+        [metadactyl.util.service]
+        [slingshot.slingshot :only [throw+]]
+        [ring.util.http-response :only [ok]]))
 
 (def volumes-from-warning
   (str "\n\n#### Warning\n"
@@ -23,260 +23,261 @@
   `(fn []
      (let [retval# ~@funccall]
        (if (nil? retval#)
-         (service/not-found-response (str "A container for " ~tool-id " was not found."))
-         (service/success-response retval#)))))
+         (throw+ {:type :clojure-commons.exception/not-found
+                  :error (str "A container for " ~tool-id " was not found.")})
+         (ok retval#)))))
 
 (defroutes* container-images
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params SecuredQueryParams]
         :return Images
         :summary "List Container Images"
         :description "Returns all of the container images defined in the database."
-        (service/trap uri list-images))
+        (ok (list-images)))
 
-  (GET* "/:image-id" [:as {uri :uri}]
+  (GET* "/:image-id" []
         :path-params [image-id :- ImageId]
         :query [params SecuredQueryParams]
         :return Image
         :summary "Container Image"
         :description "Returns a JSON description of a container image."
-        (service/trap uri image-info image-id))
+        (ok (image-info image-id)))
 
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
         :query [params SecuredQueryParams]
         :body [body NewImage]
         :return Image
         :summary "Add Container Image"
         :description "Adds a new container image to the system."
-        (service/trap uri add-image-info body))
+        (ok (add-image-info body)))
 
-  (POST* "/:image-id/name" [:as {uri :uri}]
+  (POST* "/:image-id/name" []
         :path-params [image-id :- ImageId]
         :query [params SecuredQueryParams]
         :body [body ImageName]
         :return Image
         :summary "Update Container Image Name"
         :description "Updates a container image's name field."
-        (service/trap uri modify-image-info image-id body))
+        (ok (modify-image-info image-id body)))
 
-  (POST* "/:image-id/url" [:as {uri :uri}]
+  (POST* "/:image-id/url" []
         :path-params [image-id :- ImageId]
         :query [params SecuredQueryParams]
         :body [body ImageURL]
         :return Image
         :summary "Update Container Image URL"
         :description "Updates a container image's url field."
-        (service/trap uri modify-image-info image-id body))
+        (ok (modify-image-info image-id body)))
 
-  (POST* "/:image-id/tag" [:as {uri :uri}]
+  (POST* "/:image-id/tag" []
         :path-params [image-id :- ImageId]
         :query [params SecuredQueryParams]
         :body [body ImageTag]
         :return Image
         :summary "Update Container Image Tag"
         :description "Updates a container image's tag field."
-        (service/trap uri modify-image-info image-id body))
+        (ok (modify-image-info image-id body)))
 
-  (DELETE* "/:image-id" [:as {uri :uri}]
+  (DELETE* "/:image-id" []
         :path-params [image-id :- ImageId]
         :query [params SecuredQueryParams]
         :return nil
         :summary "Delete Container Image"
         :description "Deletes a container image from the system."
-        (service/trap uri delete-image image-id)))
+        (ok (delete-image image-id))))
 
  (defroutes* data-containers
-   (GET* "/" [:as {uri :uri}]
+   (GET* "/" []
          :query [params SecuredQueryParams]
          :return DataContainers
          :summary "List Data Containers"
          :description "Lists all of the available data containers."
-         (service/trap uri list-data-containers))
+         (ok (list-data-containers)))
 
-   (GET* "/:data-container-id" [:as {uri :uri}]
+   (GET* "/:data-container-id" []
          :path-params [data-container-id :- DataContainerIdParam]
          :query [params SecuredQueryParams]
          :return DataContainer
          :summary "Data Container"
          :description "Returns a JSON description of a data container."
-         (service/trap uri data-container data-container-id)))
+         (ok (data-container data-container-id))))
 
 (defroutes* admin-data-containers
-  (PATCH* "/:data-container-id" [:as {uri :uri}]
+  (PATCH* "/:data-container-id" []
           :path-params [data-container-id :- DataContainerIdParam]
           :query [params SecuredQueryParams]
           :body [body DataContainerUpdateRequest]
           :return DataContainer
           :summary "Update Data Container"
           :description "Updates a data container's settings."
-          (service/trap uri modify-data-container data-container-id body)))
+          (ok (modify-data-container data-container-id body))))
 
 (defroutes* tools
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params ToolSearchParams]
         :return ToolListing
         :summary "Search Tools"
         :description "This endpoint allows users to search for a tool with a name or description that
         contains the given search term."
-        (ce/trap uri #(search-tools params)))
+        (ok (search-tools params)))
 
-  (GET* "/:tool-id" [:as {uri :uri}]
+  (GET* "/:tool-id" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return Tool
         :summary "Get a Tool"
         :description "This endpoint returns the details for one tool."
-        (ce/trap uri #(get-tool tool-id)))
+        (ok (get-tool tool-id)))
 
-  (GET* "/:tool-id/container" [:as {uri :uri}]
+  (GET* "/:tool-id/container" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return ToolContainer
         :summary "Tool Container Information"
         :description "This endpoint returns container information associated with a tool. This endpoint
         returns a 404 if the tool is not run inside a container."
-        (ce/trap uri (requester tool-id (tool-container-info tool-id))))
+        (requester tool-id (tool-container-info tool-id)))
 
-  (GET* "/:tool-id/container/devices" [:as {uri :uri}]
+  (GET* "/:tool-id/container/devices" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return Devices
         :summary "Tool Container Device Information"
         :description "Returns device information for the container associated with a tool."
-        (ce/trap uri (requester tool-id (tool-device-info tool-id))))
+        (requester tool-id (tool-device-info tool-id)))
 
-  (GET* "/:tool-id/container/devices/:device-id" [:as {uri :uri}]
+  (GET* "/:tool-id/container/devices/:device-id" []
         :path-params [tool-id :- ToolIdParam,
                       device-id :- DeviceIdParam]
         :query [params SecuredQueryParams]
         :return Device
         :summary "Tool Container Device Information"
         :description "Returns device information for the container associated with a tool."
-        (ce/trap uri (requester tool-id (tool-device tool-id device-id))))
+        (requester tool-id (tool-device tool-id device-id)))
 
-  (GET* "/:tool-id/container/devices/:device-id/host-path" [:as {uri :uri}]
+  (GET* "/:tool-id/container/devices/:device-id/host-path" []
         :path-params [tool-id :- ToolIdParam device-id :- DeviceIdParam]
         :query [params SecuredQueryParams]
         :return DeviceHostPath
         :summary "Tool Container Device Host Path"
         :description "Returns a device's host path."
-        (ce/trap uri (requester tool-id (device-field tool-id device-id :host_path))))
+        (requester tool-id (device-field tool-id device-id :host_path)))
 
-  (GET* "/:tool-id/container/devices/:device-id/container-path" [:as {uri :uri}]
+  (GET* "/:tool-id/container/devices/:device-id/container-path" []
         :path-params [tool-id :- ToolIdParam device-id :- DeviceIdParam]
         :query [params SecuredQueryParams]
         :return DeviceContainerPath
         :summary "Tool Device Container Path"
         :description "Returns a device's in-container path."
-        (ce/trap uri (requester tool-id (device-field tool-id device-id :container_path))))
+        (requester tool-id (device-field tool-id device-id :container_path)))
 
-  (GET* "/:tool-id/container/cpu-shares" [:as {uri :uri}]
+  (GET* "/:tool-id/container/cpu-shares" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return CPUShares
         :summary "Tool Container CPU Shares"
         :description "Returns the number of shares of the CPU that the tool container will receive."
-        (ce/trap uri (requester tool-id (get-settings-field tool-id :cpu_shares))))
+        (requester tool-id (get-settings-field tool-id :cpu_shares)))
 
-  (GET* "/:tool-id/container/memory-limit" [:as {uri :uri}]
+  (GET* "/:tool-id/container/memory-limit" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return MemoryLimit
         :summary "Tool Container Memory Limit"
         :description "Returns the maximum amount of RAM that can be allocated to the tool container (in bytes)."
-        (ce/trap uri (requester tool-id (get-settings-field tool-id :memory_limit))))
+        (requester tool-id (get-settings-field tool-id :memory_limit)))
 
-  (GET* "/:tool-id/container/network-mode" [:as {uri :uri}]
+  (GET* "/:tool-id/container/network-mode" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return NetworkMode
         :summary "Tool Container Network Mode"
         :description "Returns the network mode the tool container will operate in. Usually 'bridge' or 'none'."
-        (ce/trap uri (requester tool-id (get-settings-field tool-id :network_mode))))
+        (requester tool-id (get-settings-field tool-id :network_mode)))
 
-  (GET* "/:tool-id/container/working-directory" [:as {uri :uri}]
+  (GET* "/:tool-id/container/working-directory" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return WorkingDirectory
         :summary "Tool Container Working Directory"
         :description "Sets the initial working directory for the tool container."
-        (ce/trap uri (requester tool-id (get-settings-field tool-id :working_directory))))
+        (requester tool-id (get-settings-field tool-id :working_directory)))
 
-  (GET* "/:tool-id/container/entrypoint" [:as {uri :uri}]
+  (GET* "/:tool-id/container/entrypoint" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return Entrypoint
         :summary "Tool Container Entrypoint"
         :description "Get the entrypoint setting for the tool container."
-        (ce/trap uri (requester tool-id (get-settings-field tool-id :entrypoint))))
+        (requester tool-id (get-settings-field tool-id :entrypoint)))
 
-  (GET* "/:tool-id/container/name" [:as {uri :uri}]
+  (GET* "/:tool-id/container/name" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return ContainerName
         :summary "Tool Container Name"
         :description "The user supplied name that the container will be assigned when it runs."
-        (ce/trap uri (requester tool-id (get-settings-field tool-id :name))))
+        (requester tool-id (get-settings-field tool-id :name)))
 
-  (GET* "/:tool-id/container/volumes" [:as {uri :uri}]
+  (GET* "/:tool-id/container/volumes" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return Volumes
         :summary "Tool Container Volume Information"
         :description "Returns volume information for the container associated with a tool."
-        (ce/trap uri (requester tool-id (tool-volume-info tool-id))))
+        (requester tool-id (tool-volume-info tool-id)))
 
-  (GET* "/:tool-id/container/volumes/:volume-id" [:as {uri :uri}]
+  (GET* "/:tool-id/container/volumes/:volume-id" []
         :path-params [tool-id :- ToolIdParam volume-id :- VolumeIdParam]
         :query [params SecuredQueryParams]
         :return Volume
         :summary "Tool Container Volume Information"
         :description "Returns volume information for the container associated with a tool."
-        (ce/trap uri (requester tool-id (tool-volume tool-id volume-id))))
+        (requester tool-id (tool-volume tool-id volume-id)))
 
-  (GET* "/:tool-id/container/volumes/:volume-id/host-path" [:as {uri :uri}]
+  (GET* "/:tool-id/container/volumes/:volume-id/host-path" []
         :path-params [tool-id :- ToolIdParam volume-id :- VolumeIdParam]
         :query [params SecuredQueryParams]
         :return VolumeHostPath
         :summary "Tool Container Volume Host Path"
         :description "Returns volume host path for the container associated with a tool."
-        (ce/trap uri (requester tool-id (volume-field tool-id volume-id :host_path))))
+        (requester tool-id (volume-field tool-id volume-id :host_path)))
 
-  (GET* "/:tool-id/container/volumes/:volume-id/container-path" [:as {uri :uri}]
+  (GET* "/:tool-id/container/volumes/:volume-id/container-path" []
         :path-params [tool-id :- ToolIdParam volume-id :- VolumeIdParam]
         :query [params SecuredQueryParams]
         :return VolumeContainerPath
         :summary "Tool Container Volume Container Path"
         :description "Returns volume container path for the container associated with a tool."
-        (ce/trap uri (requester tool-id (volume-field tool-id volume-id :container_path))))
+        (requester tool-id (volume-field tool-id volume-id :container_path)))
 
-  (GET* "/:tool-id/container/volumes-from" [:as {uri :uri}]
+  (GET* "/:tool-id/container/volumes-from" []
         :path-params [tool-id :- ToolIdParam]
         :query [params SecuredQueryParams]
         :return VolumesFromList
         :summary "Tool Container Volumes From Information"
         :description "Returns a list of container names that the container associated with the tool should import volumes from."
-        (ce/trap uri (requester tool-id (tool-volumes-from-info tool-id))))
+        (requester tool-id (tool-volumes-from-info tool-id)))
 
-  (GET* "/:tool-id/container/volumes-from/:volumes-from-id" [:as {uri :uri}]
+  (GET* "/:tool-id/container/volumes-from/:volumes-from-id" []
         :path-params [tool-id :- ToolIdParam volumes-from-id :- VolumesFromIdParam]
         :query [params SecuredQueryParams]
         :return VolumesFrom
         :summary "Tool Container Volumes From Information"
         :description "Returns the data container settings for the given `volumes-from-id` the tool
          should import volumes from."
-        (ce/trap uri (requester tool-id (tool-volumes-from tool-id volumes-from-id)))))
+        (requester tool-id (tool-volumes-from tool-id volumes-from-id))))
 
 (defroutes* tool-requests
-  (GET* "/" [:as {uri :uri}]
+  (GET* "/" []
         :query [params ToolRequestListingParams]
         :return ToolRequestListing
         :summary "List Tool Requests"
         :description "This endpoint lists high level details about tool requests that have been submitted.
         A user may track their own tool requests with this endpoint."
-        (service/trap uri list-tool-requests (assoc params :username (:username current-user))))
+        (ok (list-tool-requests (assoc params :username (:username current-user)))))
 
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
          :query [params SecuredQueryParams]
          :body [body (describe ToolRequest
                        "A tool installation request. One of `source_url` or `source_upload_file`
@@ -286,159 +287,159 @@
          :description "This service submits a request for a tool to be installed so that it can be used
          from within the Discovery Environment. The installation request and all status updates
          related to the tool request will be tracked in the Discovery Environment database."
-         (service/trap uri submit-tool-request current-user body))
+         (ok (submit-tool-request current-user body)))
 
-  (GET* "/status-codes" [:as {uri :uri}]
+  (GET* "/status-codes" []
         :query [params StatusCodeListingParams]
         :summary "List Tool Request Status Codes"
         :return StatusCodeListing
         :description "Tool request status codes are largely arbitrary, but once they've been used once,
         they're stored in the database so that they can be reused easily. This endpoint allows the
         caller to list the known status codes."
-        (service/trap uri list-tool-request-status-codes params)))
+        (ok (list-tool-request-status-codes params))))
 
 (defroutes* admin-tools
-  (POST* "/" [:as {uri :uri}]
+  (POST* "/" []
          :query [params SecuredQueryParams]
          :body [body (describe ToolsImportRequest "The Tools to import.")]
          :summary "Add new Tools."
          :description (str "This service adds new Tools to the DE." volumes-from-warning)
-         (ce/trap uri #(add-tools body)))
+         (add-tools body))
 
-  (PATCH* "/:tool-id" [:as {uri :uri}]
+  (PATCH* "/:tool-id" []
           :path-params [tool-id :- ToolIdParam]
           :query [params SecuredQueryParams]
           :body [body (describe ToolUpdateRequest "The Tool to update.")]
           :return Tool
           :summary "Update a Tool"
           :description "This service updates a Tool definition in the DE."
-          (ce/trap uri #(update-tool (assoc body :id tool-id))))
+          (update-tool (assoc body :id tool-id)))
 
-  (POST* "/:tool-id/container/devices" [:as {uri :uri}]
+  (POST* "/:tool-id/container/devices" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body NewDevice]
          :return Device
          :summary "Adds Device To Tool Container"
          :description "Adds a new device to a tool container."
-         (ce/trap uri (requester tool-id (add-tool-device tool-id body))))
+         (requester tool-id (add-tool-device tool-id body)))
 
-  (DELETE* "/:tool-id/container/devices/:device-id" [:as {uri :uri}]
+  (DELETE* "/:tool-id/container/devices/:device-id" []
            :path-params [tool-id :- ToolIdParam device-id :- DeviceIdParam]
            :query [params SecuredQueryParams]
            :return nil
            :summary "Delete a container device"
            :description "Deletes a device from the tool's container"
-           (ce/trap uri #(delete-tool-device tool-id device-id)))
+           (delete-tool-device tool-id device-id))
 
-  (POST* "/:tool-id/container/devices/:device-id/host-path" [:as {uri :uri}]
+  (POST* "/:tool-id/container/devices/:device-id/host-path" []
          :path-params [tool-id :- ToolIdParam device-id :- DeviceIdParam]
          :query [params SecuredQueryParams]
          :body [body DeviceHostPath]
          :return DeviceHostPath
          :summary "Update Tool Container Device Host Path"
          :description "This endpoint updates a device's host path for the tool's container."
-         (ce/trap uri (requester tool-id (update-device-field tool-id device-id :host_path (:host_path body)))))
+         (requester tool-id (update-device-field tool-id device-id :host_path (:host_path body))))
 
-  (POST* "/:tool-id/container/devices/:device-id/container-path" [:as {uri :uri}]
+  (POST* "/:tool-id/container/devices/:device-id/container-path" []
          :path-params [tool-id :- ToolIdParam device-id :- DeviceIdParam]
          :query [params SecuredQueryParams]
          :body [body DeviceContainerPath]
          :return DeviceContainerPath
          :summary "Update Tool Device Container Path"
          :description "This endpoint updates a device's container path for the tool's container."
-         (ce/trap uri (requester tool-id (update-device-field tool-id device-id :container_path (:container_path body)))))
+         (requester tool-id (update-device-field tool-id device-id :container_path (:container_path body))))
 
-  (POST* "/:tool-id/container/entrypoint" [:as {uri :uri}]
+  (POST* "/:tool-id/container/entrypoint" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body Entrypoint]
          :return Entrypoint
          :summary "Update Tool Container Entrypoint"
          :description "This endpoint updates an entrypoint for the tool's container."
-         (ce/trap uri (requester tool-id (update-settings-field tool-id :entrypoint (:entrypoint body)))))
+         (requester tool-id (update-settings-field tool-id :entrypoint (:entrypoint body))))
 
-  (POST* "/:tool-id/container/cpu-shares" [:as {uri :uri}]
+  (POST* "/:tool-id/container/cpu-shares" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body CPUShares]
          :return CPUShares
          :summary "Update Tool Container CPU Shares"
          :description "This endpoint updates a the CPU shares for the tool's container."
-         (ce/trap uri (requester tool-id (update-settings-field tool-id :cpu_shares (:cpu_shares body)))))
+         (requester tool-id (update-settings-field tool-id :cpu_shares (:cpu_shares body))))
 
-  (POST* "/:tool-id/container/memory-limit" [:as {uri :uri}]
+  (POST* "/:tool-id/container/memory-limit" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body MemoryLimit]
          :return MemoryLimit
          :summary "Update Tool Container Memory Limit"
          :description "This endpoint updates a the memory limit for the tool's container."
-         (ce/trap uri (requester tool-id (update-settings-field tool-id :memory_limit (:memory_limit body)))))
+         (requester tool-id (update-settings-field tool-id :memory_limit (:memory_limit body))))
 
-  (POST* "/:tool-id/container/network-mode" [:as {uri :uri}]
+  (POST* "/:tool-id/container/network-mode" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body NetworkMode]
          :return NetworkMode
          :summary "Update Tool Container Network Mode"
          :description "This endpoint updates a the network mode for the tool's container."
-         (ce/trap uri (requester tool-id (update-settings-field tool-id :network_mode (:network_mode body)))))
+         (requester tool-id (update-settings-field tool-id :network_mode (:network_mode body))))
 
-  (POST* "/:tool-id/container/working-directory" [:as {uri :uri}]
+  (POST* "/:tool-id/container/working-directory" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body WorkingDirectory]
          :return WorkingDirectory
          :summary "Update Tool Container Working Directory"
          :description "This endpoint updates the working directory for the tool's container."
-         (ce/trap uri (requester tool-id (update-settings-field tool-id :working_directory (:working_directory body)))))
+         (requester tool-id (update-settings-field tool-id :working_directory (:working_directory body))))
 
-  (POST* "/:tool-id/container/name" [:as {uri :uri}]
+  (POST* "/:tool-id/container/name" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body ContainerName]
          :return ContainerName
          :summary "Update Tool Container Name"
          :description "This endpoint updates the container name for the tool's container."
-         (ce/trap uri (requester tool-id (update-settings-field tool-id :name (:name body)))))
+         (requester tool-id (update-settings-field tool-id :name (:name body))))
 
-  (POST* "/:tool-id/container/volumes" [:as {uri :uri}]
+  (POST* "/:tool-id/container/volumes" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body NewVolume]
          :return Volume
          :summary "Tool Container Volume Information"
          :description "This endpoint updates volume information for the container associated with a tool."
-         (ce/trap uri (requester tool-id (add-tool-volume tool-id body))))
+         (requester tool-id (add-tool-volume tool-id body)))
 
-  (DELETE* "/:tool-id/container/volumes/:volume-id" [:as {uri :uri}]
+  (DELETE* "/:tool-id/container/volumes/:volume-id" []
            :path-params [tool-id :- ToolIdParam volume-id :- VolumeIdParam]
            :query [params SecuredQueryParams]
            :return nil
            :summary "Delete Tool Container Volume"
            :description "Deletes a volume from a tool container."
-           (ce/trap uri #(delete-tool-volume tool-id volume-id)))
+           (ok (delete-tool-volume tool-id volume-id)))
 
-  (POST* "/:tool-id/container/volumes/:volume-id/host-path" [:as {uri :uri}]
+  (POST* "/:tool-id/container/volumes/:volume-id/host-path" []
          :path-params [tool-id :- ToolIdParam volume-id :- VolumeIdParam]
          :query [params SecuredQueryParams]
          :body [body VolumeHostPath]
          :return VolumeHostPath
          :summary "Update Tool Container Volume Host Path"
          :description "This endpoint updates a volume host path for the tool's container."
-         (ce/trap uri (requester tool-id (update-volume-field tool-id volume-id :host_path (:host_path body)))))
+         (requester tool-id (update-volume-field tool-id volume-id :host_path (:host_path body))))
 
-  (POST* "/:tool-id/container/volumes/:volume-id/container-path" [:as {uri :uri}]
+  (POST* "/:tool-id/container/volumes/:volume-id/container-path" []
          :path-params [tool-id :- ToolIdParam volume-id :- VolumeIdParam]
          :query [params SecuredQueryParams]
          :body [body VolumeContainerPath]
          :return VolumeContainerPath
          :summary "Update Tool Container Volume Container Path"
          :description "This endpoint updates a volume container path for the tool's container."
-         (ce/trap uri (requester tool-id (update-volume-field tool-id volume-id :container_path (:container_path body)))))
+         (requester tool-id (update-volume-field tool-id volume-id :container_path (:container_path body))))
 
-  (PUT* "/:tool-id/container/volumes-from" [:as {uri :uri}]
+  (PUT* "/:tool-id/container/volumes-from" []
          :path-params [tool-id :- ToolIdParam]
          :query [params SecuredQueryParams]
          :body [body NewVolumesFrom]
@@ -447,7 +448,7 @@
          :description (str
                         "Adds a new container from which the tool container will bind mount volumes."
                         volumes-from-warning)
-         (ce/trap uri (requester tool-id (add-tool-volumes-from tool-id body))))
+         (requester tool-id (add-tool-volumes-from tool-id body)))
 
   (DELETE* "/:tool-id/container/volumes-from/:volumes-from-id" [:as {uri :uri}]
            :path-params [tool-id :- ToolIdParam volumes-from-id :- VolumesFromIdParam]
@@ -455,4 +456,4 @@
            :return nil
            :summary "Delete Tool Container Volumes From Information"
            :description "Deletes a container name that the tool container should import volumes from."
-           (ce/trap uri #(delete-tool-volumes-from tool-id volumes-from-id))))
+           (ok (delete-tool-volumes-from tool-id volumes-from-id))))

--- a/services/metadactyl-clj/src/metadactyl/routes/tools.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/tools.clj
@@ -23,7 +23,7 @@
   `(fn []
      (let [retval# ~@funccall]
        (if (nil? retval#)
-         (throw+ {:type :clojure-commons.exception/not-found
+         (throw+ {:type  :clojure-commons.exception/not-found
                   :error (str "A container for " ~tool-id " was not found.")})
          (ok retval#)))))
 
@@ -304,7 +304,7 @@
          :body [body (describe ToolsImportRequest "The Tools to import.")]
          :summary "Add new Tools."
          :description (str "This service adds new Tools to the DE." volumes-from-warning)
-         (add-tools body))
+         (ok (add-tools body)))
 
   (PATCH* "/:tool-id" []
           :path-params [tool-id :- ToolIdParam]
@@ -313,7 +313,7 @@
           :return Tool
           :summary "Update a Tool"
           :description "This service updates a Tool definition in the DE."
-          (update-tool (assoc body :id tool-id)))
+          (ok (update-tool (assoc body :id tool-id))))
 
   (POST* "/:tool-id/container/devices" []
          :path-params [tool-id :- ToolIdParam]
@@ -330,7 +330,7 @@
            :return nil
            :summary "Delete a container device"
            :description "Deletes a device from the tool's container"
-           (delete-tool-device tool-id device-id))
+           (ok (delete-tool-device tool-id device-id)))
 
   (POST* "/:tool-id/container/devices/:device-id/host-path" []
          :path-params [tool-id :- ToolIdParam device-id :- DeviceIdParam]
@@ -450,7 +450,7 @@
                         volumes-from-warning)
          (requester tool-id (add-tool-volumes-from tool-id body)))
 
-  (DELETE* "/:tool-id/container/volumes-from/:volumes-from-id" [:as {uri :uri}]
+  (DELETE* "/:tool-id/container/volumes-from/:volumes-from-id" []
            :path-params [tool-id :- ToolIdParam volumes-from-id :- VolumesFromIdParam]
            :query [params SecuredQueryParams]
            :return nil

--- a/services/metadactyl-clj/src/metadactyl/routes/users.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/users.clj
@@ -2,35 +2,35 @@
   (:use [common-swagger-api.schema]
         [metadactyl.routes.domain.user]
         [metadactyl.routes.params]
-        [metadactyl.user :only [current-user]])
-  (:require [metadactyl.service.users :as users]
-            [metadactyl.util.service :as service]))
+        [metadactyl.user :only [current-user]]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.service.users :as users]))
 
 (defroutes* users
-  (POST* "/by-id" [:as {:keys [uri]}]
+  (POST* "/by-id" []
          :query [params SecuredQueryParams]
          :body [body (describe UserIds "The list of user IDs to look up.")]
          :return Users
          :summary "Look up usernames"
          :description "This endpoint returns usernames for internal user IDs."
-         (service/trap uri users/by-id body))
+         (ok (users/by-id body)))
 
-  (GET* "/authenticated" [:as {:keys [uri]}]
+  (GET* "/authenticated" []
         :query [params SecuredQueryParams]
         :return User
         :summary "Get the Authenticated User"
         :description "This endpoint returns information about the authenticated user."
-        (service/trap uri users/authenticated current-user))
+        (ok (users/authenticated current-user)))
 
-  (POST* "/login" [:as {:keys [uri]}]
+  (POST* "/login" []
          :query [params LoginParams]
          :return LoginResponse
          :summary "Record a User Login"
          :description "Donkey calls this service to record when a user logs in."
-         (service/trap uri users/login current-user params))
+         (ok (users/login current-user params)))
 
-  (POST* "/logout" [:as {:keys [uri]}]
+  (POST* "/logout" []
          :query [params LogoutParams]
          :summary "Record a User Logout"
          :description "Donkey calls this service to record when a user logs out."
-         (service/trap uri users/logout current-user params)))
+         (ok (users/logout current-user params))))

--- a/services/metadactyl-clj/src/metadactyl/routes/workspaces.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/workspaces.clj
@@ -2,15 +2,15 @@
   (:use [common-swagger-api.schema]
         [metadactyl.routes.domain.workspace]
         [metadactyl.routes.params]
-        [metadactyl.user :only [current-user]])
-  (:require [metadactyl.service.workspace :as workspace]
-            [metadactyl.util.service :as service]))
+        [metadactyl.user :only [current-user]]
+        [ring.util.http-response :only [ok]])
+  (:require [metadactyl.service.workspace :as workspace]))
 
 (defroutes* workspaces
-  (GET* "/" [:as {:keys [uri]}]
+  (GET* "/" []
         :query [params SecuredQueryParams]
         :return Workspace
         :summary "Obtain user workspace information."
         :description "This endpoint returns information about the workspace belonging to the
         authenticated user."
-        (service/trap uri workspace/get-workspace current-user)))
+        (ok (workspace/get-workspace current-user))))

--- a/services/metadactyl-clj/src/metadactyl/service/apps.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps.clj
@@ -4,7 +4,6 @@
         [slingshot.slingshot :only [try+ throw+]])
   (:require [cemerick.url :as curl]
             [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
             [mescal.de :as agave]
             [metadactyl.clients.notifications :as cn]
             [metadactyl.persistence.jobs :as jp]
@@ -17,7 +16,6 @@
             [metadactyl.user :as user]
             [metadactyl.util.config :as config]
             [metadactyl.util.json :as json-util]
-            [metadactyl.util.service :as service]
             [service-logging.thread-context :as tc]))
 
 (defn- authorization-uri
@@ -30,8 +28,8 @@
 
 (defn- authorization-redirect
   [server-info username state-info]
-  (throw+ {:error_code ce/ERR_TEMPORARILY_MOVED
-           :location   (authorization-uri server-info username state-info)}))
+  (throw+ {:type       :clojure-commons.exception/temporary-redirect
+           :location (authorization-uri server-info username state-info)}))
 
 (defn- has-access-token
   [{:keys [api-name] :as server-info} username]

--- a/services/metadactyl-clj/src/metadactyl/service/apps.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps.clj
@@ -28,7 +28,7 @@
 
 (defn- authorization-redirect
   [server-info username state-info]
-  (throw+ {:type       :clojure-commons.exception/temporary-redirect
+  (throw+ {:type     :clojure-commons.exception/temporary-redirect
            :location (authorization-uri server-info username state-info)}))
 
 (defn- has-access-token

--- a/services/metadactyl-clj/src/metadactyl/service/apps/agave/jobs.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/agave/jobs.clj
@@ -8,7 +8,6 @@
             [clojure-commons.file-utils :as ft]
             [kameleon.db :as db]
             [kameleon.uuids :as uuids]
-            [metadactyl.clients.notifications :as cn]
             [metadactyl.persistence.jobs :as jp]
             [metadactyl.util.config :as config]
             [metadactyl.util.json :as json-util]

--- a/services/metadactyl-clj/src/metadactyl/service/apps/agave/listings.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/agave/listings.clj
@@ -34,7 +34,7 @@
         (map (juxt :id identity))
         (into {})
         (vector))
-   (catch [:error_code ce/ERR_UNAVAILABLE] _
+   (catch [:type :clojure-commons.exception/unavailable] _
      (log/warn (:throwable &throw-context) "Agave app table retrieval timed out")
      [])
    (catch :status _

--- a/services/metadactyl-clj/src/metadactyl/service/apps/combined/jobs.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/combined/jobs.clj
@@ -2,14 +2,12 @@
   (:use [slingshot.slingshot :only [try+ throw+]])
   (:require [cheshire.core :as cheshire]
             [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
             [clojure-commons.file-utils :as ft]
             [kameleon.db :as db]
             [kameleon.uuids :as uuids]
             [metadactyl.persistence.app-metadata :as ap]
             [metadactyl.persistence.jobs :as jp]
             [metadactyl.service.apps.combined.util :as cu]
-            [metadactyl.util.json :as json-util]
             [metadactyl.util.service :as service]))
 
 (defn- app-step-partitioner
@@ -41,8 +39,8 @@
   "Verifies that at least one step is associated with a job submission."
   [app-id steps]
   (when (empty? steps)
-    (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-             :reason     (str "app " app-id " has no steps")}))
+    (throw+ {:type  :clojure-commons.exception/illegal-argument
+             :error (str "app " app-id " has no steps")}))
   steps)
 
 (defn- build-job-save-info

--- a/services/metadactyl-clj/src/metadactyl/service/apps/combined/util.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/combined/util.clj
@@ -1,9 +1,7 @@
 (ns metadactyl.service.apps.combined.util
   (:use [metadactyl.service.util :only [sort-apps apply-offset apply-limit uuid?]]
         [slingshot.slingshot :only [throw+]])
-  (:require [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
-            [metadactyl.persistence.app-metadata :as ap]
+  (:require [metadactyl.persistence.app-metadata :as ap]
             [metadactyl.persistence.jobs :as jp]))
 
 (defn apply-default-search-params
@@ -24,12 +22,12 @@
 (defn get-apps-client
   ([clients]
      (or (first (filter #(.canEditApps %) clients))
-         (throw+ {:error_code ce/ERR_BAD_REQUEST
-                  :reason     "apps are not editable at this time."})))
+         (throw+ {:type  :clojure-commons.exception/bad-request-field
+                  :error "apps are not editable at this time."})))
   ([clients client-name]
      (or (first (filter #(= client-name (.getClientName %)) clients))
-         (throw+ {:error_code ce/ERR_BAD_REQUEST
-                  :reason     (str "unrecognized client name " client-name)}))))
+         (throw+ {:type  :clojure-commons.exception/bad-request-field
+                  :error (str "unrecognized client name " client-name)}))))
 
 (defn apps-client-for-job
   [{app-id :app_id :as submission} clients]

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/admin.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/admin.clj
@@ -6,7 +6,6 @@
         [metadactyl.util.config :only [workspace-public-id]]
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
             [kameleon.app-groups :as app-groups]
             [metadactyl.persistence.app-metadata :as persistence]))
 
@@ -26,43 +25,43 @@
   "Validates the length of an App Category name."
   [name]
   (when (> (count name) max-app-category-name-len)
-    (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-             :reason     "App Category name too long."
-             :name       name})))
+    (throw+ {:type   :clojure-commons.exception/illegal-argument
+             :error  "App Category name too long."
+             :name name})))
 
 (defn- validate-subcategory-name
   "Validates that the given subcategory name is available under the given App Category parent ID."
   [parent-id name]
   (when (app-groups/category-contains-subcategory? parent-id name)
-    (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-             :reason     "Parent App Category already contains a subcategory with that name"
-             :parent_id  parent-id
-             :name       name})))
+    (throw+ {:type   :clojure-commons.exception/illegal-argument
+             :error  "Parent App Category already contains a subcategory with that name"
+             :parent_id parent-id
+             :name name})))
 
 (defn- validate-category-empty
   "Validates that the given App Category contains no Apps directly under it."
   [parent-id]
   (when (app-groups/category-contains-apps? parent-id)
-    (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-             :reason     "Parent App Category already contains Apps"
-             :parent_id  parent-id})))
+    (throw+ {:type   :clojure-commons.exception/illegal-argument
+             :error  "Parent App Category already contains Apps"
+             :parent_id parent-id})))
 
 (defn- validate-category-hierarchy-empty
   "Validates that the given App Category and its subcategories contain no Apps."
   [category-id requestor]
   (when (app-groups/category-hierarchy-contains-apps? category-id)
-    (throw+ {:error_code   ce/ERR_ILLEGAL_ARGUMENT
-             :reason       "App Category, or one of its subcategories, still contain Apps"
+    (throw+ {:type   :clojure-commons.exception/illegal-argument
+             :error  "App Category, or one of its subcategories, still contain Apps"
              :category_id  category-id
              :requested_by requestor})))
 
 (defn- validate-category-not-ancestor-of-parent
   [category-id parent-id]
   (when (app-groups/category-ancestor-of-subcategory? category-id parent-id)
-    (throw+ {:error_code   ce/ERR_ILLEGAL_ARGUMENT
-             :reason       "App Category is an ancestor of the destination Category"
-             :category_id  category-id
-             :parent_id    parent-id})))
+    (throw+ {:type   :clojure-commons.exception/illegal-argument
+             :error  "App Category is an ancestor of the destination Category"
+             :category_id category-id
+             :parent_id   parent-id})))
 
 (defn delete-app
   "This service marks an existing app as deleted in the database."

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/admin.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/admin.clj
@@ -25,41 +25,41 @@
   "Validates the length of an App Category name."
   [name]
   (when (> (count name) max-app-category-name-len)
-    (throw+ {:type   :clojure-commons.exception/illegal-argument
-             :error  "App Category name too long."
-             :name name})))
+    (throw+ {:type  :clojure-commons.exception/illegal-argument
+             :error "App Category name too long."
+             :name  name})))
 
 (defn- validate-subcategory-name
   "Validates that the given subcategory name is available under the given App Category parent ID."
   [parent-id name]
   (when (app-groups/category-contains-subcategory? parent-id name)
-    (throw+ {:type   :clojure-commons.exception/illegal-argument
-             :error  "Parent App Category already contains a subcategory with that name"
+    (throw+ {:type      :clojure-commons.exception/illegal-argument
+             :error     "Parent App Category already contains a subcategory with that name"
              :parent_id parent-id
-             :name name})))
+             :name      name})))
 
 (defn- validate-category-empty
   "Validates that the given App Category contains no Apps directly under it."
   [parent-id]
   (when (app-groups/category-contains-apps? parent-id)
-    (throw+ {:type   :clojure-commons.exception/illegal-argument
-             :error  "Parent App Category already contains Apps"
+    (throw+ {:type      :clojure-commons.exception/illegal-argument
+             :error     "Parent App Category already contains Apps"
              :parent_id parent-id})))
 
 (defn- validate-category-hierarchy-empty
   "Validates that the given App Category and its subcategories contain no Apps."
   [category-id requestor]
   (when (app-groups/category-hierarchy-contains-apps? category-id)
-    (throw+ {:type   :clojure-commons.exception/illegal-argument
-             :error  "App Category, or one of its subcategories, still contain Apps"
+    (throw+ {:type         :clojure-commons.exception/illegal-argument
+             :error        "App Category, or one of its subcategories, still contain Apps"
              :category_id  category-id
              :requested_by requestor})))
 
 (defn- validate-category-not-ancestor-of-parent
   [category-id parent-id]
   (when (app-groups/category-ancestor-of-subcategory? category-id parent-id)
-    (throw+ {:type   :clojure-commons.exception/illegal-argument
-             :error  "App Category is an ancestor of the destination Category"
+    (throw+ {:type        :clojure-commons.exception/illegal-argument
+             :error       "App Category is an ancestor of the destination Category"
              :category_id category-id
              :parent_id   parent-id})))
 

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/categorization.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/categorization.clj
@@ -4,8 +4,7 @@
         [kameleon.app-groups]
         [kameleon.entities]
         [metadactyl.validation]
-        [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as error-codes]))
+        [slingshot.slingshot :only [throw+]]))
 
 (defn- categorize-app
   "Associates an app with an app category."
@@ -19,9 +18,10 @@
   [app-id path]
   (let [app (get-app-by-id app-id)]
     (when (nil? app)
-      (throw+ {:error_code error-codes/ERR_NOT_FOUND
+      (throw+ {:type :clojure-commons.exception/not-found
                :app-id     app-id
-               :path       path}))))
+               :path       path
+               :error (str "Could not locate app with ID: " app-id)}))))
 
 (defn- load-category
   [category-id]
@@ -31,18 +31,21 @@
   [path category-id]
   (let [category (load-category category-id)]
     (when (nil? category)
-      (throw+ {:error_code error-codes/ERR_NOT_FOUND
-               :path       path}))
+      (throw+ {:type   :clojure-commons.exception/not-found
+               :path path
+               :error (str "Could not locate app category with ID: " category-id)}))
+
     (when (seq (:app_categories category))
-      (throw+ {:error_code error-codes/ERR_BAD_OR_MISSING_FIELD
-               :reason     (str "category " category-id " contains subcategories")
-               :path       path}))))
+      (throw+ {:type   :clojure-commons.exception/missing-request-field
+               :error  (str "category " category-id " contains subcategories")
+               :path path}))))
 
 (defn- validate-category-ids
   [category-ids path]
   (when (zero? (count category-ids))
-    (throw+ {:error_code error-codes/ERR_BAD_OR_MISSING_FIELD
-             :path       path}))
+    (throw+ {:type   :clojure-commons.exception/missing-request-field
+             :error  (str "Missing category ids")
+             :path path}))
   (dorun (map (partial validate-category-id path) category-ids)))
 
 (defn- validate-category

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/categorization.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/categorization.clj
@@ -18,10 +18,10 @@
   [app-id path]
   (let [app (get-app-by-id app-id)]
     (when (nil? app)
-      (throw+ {:type :clojure-commons.exception/not-found
-               :app-id     app-id
-               :path       path
-               :error (str "Could not locate app with ID: " app-id)}))))
+      (throw+ {:type   :clojure-commons.exception/not-found
+               :app-id app-id
+               :path   path
+               :error  (str "Could not locate app with ID: " app-id)}))))
 
 (defn- load-category
   [category-id]
@@ -31,21 +31,21 @@
   [path category-id]
   (let [category (load-category category-id)]
     (when (nil? category)
-      (throw+ {:type   :clojure-commons.exception/not-found
-               :path path
+      (throw+ {:type  :clojure-commons.exception/not-found
+               :path  path
                :error (str "Could not locate app category with ID: " category-id)}))
 
     (when (seq (:app_categories category))
-      (throw+ {:type   :clojure-commons.exception/missing-request-field
-               :error  (str "category " category-id " contains subcategories")
-               :path path}))))
+      (throw+ {:type  :clojure-commons.exception/missing-request-field
+               :error (str "category " category-id " contains subcategories")
+               :path  path}))))
 
 (defn- validate-category-ids
   [category-ids path]
   (when (zero? (count category-ids))
-    (throw+ {:type   :clojure-commons.exception/missing-request-field
-             :error  (str "Missing category ids")
-             :path path}))
+    (throw+ {:type  :clojure-commons.exception/missing-request-field
+             :error (str "Missing category ids")
+             :path  path}))
   (dorun (map (partial validate-category-id path) category-ids)))
 
 (defn- validate-category

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/docs.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/docs.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.service.apps.de.docs
   (:use [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as ce]
-            [metadactyl.persistence.app-documentation :as dp]
+  (:require [metadactyl.persistence.app-documentation :as dp]
             [metadactyl.persistence.app-metadata :as ap]
             [metadactyl.validation :as v]))
 
@@ -15,8 +14,8 @@
   [app-id]
   (if-let [docs (dp/get-documentation app-id)]
     (assoc docs :references (get-references app-id))
-    (throw+ {:error_code ce/ERR_NOT_FOUND
-             :reason "App documentation not found"
+    (throw+ {:type   :clojure-commons.exception/not-found
+             :error  "App documentation not found"
              :app_id app-id})))
 
 (defn edit-app-docs
@@ -36,8 +35,8 @@
   "Adds an App's documentation to the database."
   [{:keys [username]} app-id {docs :documentation}]
   (when-let [current-docs (dp/get-documentation app-id)]
-    (throw+ {:error_code ce/ERR_EXISTS
-             :reason "App already has documentation"
+    (throw+ {:type   :clojure-commons.exception/exists
+             :error  "App already has documentation"
              :app_id app-id}))
   (dp/add-documentation (v/get-valid-user-id username) docs app-id)
   (get-app-docs app-id))

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/edit.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/edit.clj
@@ -160,7 +160,7 @@
     validation-rules :validation_rules
     :as param}]
   (when-not value-type
-    (throw+ {:type :clojure-commons.exception/not-writeable
+    (throw+ {:type  :clojure-commons.exception/not-writeable
              :error "App contains Parameters that cannot be copied or modified at this time."}))
   (let [param (-> param
                   format-file-params
@@ -189,7 +189,7 @@
   (let [app (get-app-details (:id app))
         task (first (:tasks app))]
     (when (empty? task)
-      (throw+ {:type :clojure-commons.exception/not-writeable
+      (throw+ {:type  :clojure-commons.exception/not-writeable
                :error "App contains no steps and cannot be copied or modified."}))
     (remove-nil-vals
       (-> app

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/edit.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/edit.clj
@@ -13,7 +13,6 @@
         [metadactyl.workspace :only [get-workspace]]
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.set :as set]
-            [clojure-commons.error-codes :as cc-errs]
             [metadactyl.persistence.app-metadata :as persistence]))
 
 (def ^:private copy-prefix "Copy of ")
@@ -161,8 +160,8 @@
     validation-rules :validation_rules
     :as param}]
   (when-not value-type
-    (throw+ {:error_code cc-errs/ERR_NOT_WRITEABLE
-             :message "App contains Parameters that cannot be copied or modified at this time."}))
+    (throw+ {:type :clojure-commons.exception/not-writeable
+             :error "App contains Parameters that cannot be copied or modified at this time."}))
   (let [param (-> param
                   format-file-params
                   (assoc :validators (map format-validator validation-rules))
@@ -190,8 +189,8 @@
   (let [app (get-app-details (:id app))
         task (first (:tasks app))]
     (when (empty? task)
-      (throw+ {:error_code cc-errs/ERR_NOT_WRITEABLE
-               :message "App contains no steps and cannot be copied or modified."}))
+      (throw+ {:type :clojure-commons.exception/not-writeable
+               :error "App contains no steps and cannot be copied or modified."}))
     (remove-nil-vals
       (-> app
           (assoc :references (map :reference_text (:app_references app))

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/jobs.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/jobs.clj
@@ -9,7 +9,6 @@
         [slingshot.slingshot :only [try+ throw+]])
   (:require [cheshire.core :as cheshire]
             [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
             [kameleon.db :as db]
             [metadactyl.clients.jex :as jex]
             [metadactyl.clients.jex-events :as jex-events]
@@ -38,9 +37,11 @@
   [job]
   (try+
    (jex/submit-job (pre-process-jex-submission job))
+   ; FIXME: Should we let this error ripple up? Not catch it?
    (catch Object _
      (log/error (:throwable &throw-context) "job submission failed")
-     (throw+ {:error_code ce/ERR_REQUEST_FAILED}))))
+     (throw+ {:type :clojure-commons.exception/request-failed
+              :error "job submission failed"}))))
 
 (defn- store-submitted-job
   "Saves information about a job in the database."

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/jobs.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/jobs.clj
@@ -37,10 +37,9 @@
   [job]
   (try+
    (jex/submit-job (pre-process-jex-submission job))
-   ; FIXME: Should we let this error ripple up? Not catch it?
    (catch Object _
      (log/error (:throwable &throw-context) "job submission failed")
-     (throw+ {:type :clojure-commons.exception/request-failed
+     (throw+ {:type  :clojure-commons.exception/request-failed
               :error "job submission failed"}))))
 
 (defn- store-submitted-job

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/jobs/params.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/jobs/params.clj
@@ -2,8 +2,6 @@
   (:use [kameleon.uuids :only [uuidify]]
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
             [me.raynes.fs :as fs]
             [metadactyl.service.apps.de.jobs.util :as util]
             [metadactyl.util.config :as config]))
@@ -54,8 +52,8 @@
 
 (defn- missing-output-filename
   [{step-id :step_id id :id}]
-  (throw+ {:error_code ce/ERR_BAD_REQUEST
-           :reason     (str "no filename found for output " id " in step " step-id)}))
+  (throw+ {:type  :clojure-commons.exception/bad-request-field
+           :error (str "no filename found for output " id " in step " step-id)}))
 
 (defn- get-output-filename
   "Obtains the name of an output filename from either the app config or the default values

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/listings.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/listings.clj
@@ -13,10 +13,7 @@
         [metadactyl.util.config]
         [metadactyl.util.conversions :only [to-long remove-nil-vals]]
         [metadactyl.workspace])
-  (:require [cemerick.url :as curl]
-            [cheshire.core :as cheshire]
-            [clojure.tools.logging :as log]
-            [metadactyl.util.service :as service]))
+  (:require [cemerick.url :as curl]))
 
 (def my-public-apps-id (uuidify "00000000-0000-0000-0000-000000000000"))
 (def trash-category-id (uuidify "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"))

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/pipeline_edit.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/pipeline_edit.clj
@@ -17,8 +17,7 @@
                                       validate-pipeline
                                       verify-app-editable]]
         [metadactyl.service.apps.de.edit :only [add-app-to-user-dev-category app-copy-name]])
-  (:require [metadactyl.service.apps.de.listings :as listings]
-            [clojure.tools.logging :as log]))
+  (:require [metadactyl.service.apps.de.listings :as listings]))
 
 (defn- add-app-type
   [step]

--- a/services/metadactyl-clj/src/metadactyl/service/apps/de/validation.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/de/validation.clj
@@ -54,7 +54,9 @@
   (when-let [tool-type (get-tool-type registry (.getComponent template))]
     (let [valid-ptypes (into #{} (get-valid-ptype-names tool-type))
           properties   (mapcat #(.getProperties %) (.getPropertyGroups template))]
-      (dorun (map #(throw+ {:type ::UnsupportedPropertyTypeException :property-type % :name (:name tool-type)})
+      (dorun (map #(throw+ {:type          ::UnsupportedPropertyTypeException
+                            :property-type %
+                            :name          (:name tool-type)})
                   (filter #(nil? (valid-ptypes %))
                           (map #(.getPropertyTypeName %) properties)))))))
 
@@ -64,7 +66,8 @@
   [template]
   (let [component-id (.getComponent template)]
    (when (string/blank? component-id)
-     (throw+ {:type ::MissingDeployedComponentException :template-id (.getId template)}))
+     (throw+ {:type        ::MissingDeployedComponentException
+              :template-id (.getId template)}))
    (when (nil? (get-deployed-component-from-database component-id))
      (throw+ {:type ::UnknownDeployedComponentException :component-id component-id}))))
 

--- a/services/metadactyl-clj/src/metadactyl/service/apps/jobs/params.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/jobs/params.clj
@@ -10,8 +10,8 @@
   [job]
   (let [submission (:submission job)]
     (when-not submission
-      (throw+ {:type :clojure-commons.exception/not-found
-               :error     "Job submission values could not be found."}))
+      (throw+ {:type  :clojure-commons.exception/not-found
+               :error "Job submission values could not be found."}))
     (:config (cheshire/decode (.getValue submission) true))))
 
 (defn- load-mapped-params

--- a/services/metadactyl-clj/src/metadactyl/service/apps/jobs/params.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/jobs/params.clj
@@ -3,8 +3,6 @@
         [slingshot.slingshot :only [throw+]])
   (:require [cheshire.core :as cheshire]
             [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
             [metadactyl.persistence.app-metadata :as ap]
             [metadactyl.service.util :as util]))
 
@@ -12,8 +10,8 @@
   [job]
   (let [submission (:submission job)]
     (when-not submission
-      (throw+ {:error_code ce/ERR_NOT_FOUND
-               :reason     "Job submission values could not be found."}))
+      (throw+ {:type :clojure-commons.exception/not-found
+               :error     "Job submission values could not be found."}))
     (:config (cheshire/decode (.getValue submission) true))))
 
 (defn- load-mapped-params

--- a/services/metadactyl-clj/src/metadactyl/service/apps/jobs/submissions.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/jobs/submissions.clj
@@ -28,8 +28,8 @@
    (data-info/get-file-stats user paths)
    (catch Object _
      (log/error (:throwable &throw-context) "job submission failed")
-     (throw+ {:error_code ce/ERR_REQUEST_FAILED
-              :message "Could not lookup info types of inputs"}))))
+     (throw+ {:type :clojure-commons.exception/request-failed
+              :error "Could not lookup info types of inputs"}))))
 
 (defn- load-path-list-stats
   [user input-paths-by-id]
@@ -54,18 +54,18 @@
 (defn- max-path-list-size-exceeded
   [max-size path actual-size]
   (throw+
-   {:error_code ce/ERR_ILLEGAL_ARGUMENT
-    :message    (str "HT Analysis Path List file exceeds maximum size of " max-size " bytes.")
-    :path       path
-    :file-size  actual-size}))
+   {:type       :clojure-commons.exception/illegal-argument
+    :error      (str "HT Analysis Path List file exceeds maximum size of " max-size " bytes.")
+    :path path
+    :file-size actual-size}))
 
 (defn- max-batch-paths-exceeded
   [max-paths first-list-path first-list-count]
   (throw+
-   {:error_code ce/ERR_ILLEGAL_ARGUMENT
-    :message    (str "The HT Analysis Path List exceeds the maximum of "
-                     max-paths
-                     " allowed paths.")
+   {:type :clojure-commons.exception/illegal-argument
+    :error    (str "The HT Analysis Path List exceeds the maximum of "
+                   max-paths
+                   " allowed paths.")
     :path       first-list-path
     :path-count first-list-count}))
 
@@ -77,8 +77,8 @@
 (defn- validate-ht-params
   [ht-params]
   (when (some (comp (partial = ap/param-multi-input-type) :type) ht-params)
-    (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-             :message "HT Analysis Path List files are not supported in multi-file inputs."})))
+    (throw+ {:type :clojure-commons.exception/illegal-argument
+             :error "HT Analysis Path List files are not supported in multi-file inputs."})))
 
 (defn- validate-path-lists
   [path-lists]
@@ -87,8 +87,8 @@
     (when (> first-list-count (config/path-list-max-paths))
       (max-batch-paths-exceeded (config/path-list-max-paths) first-list-path first-list-count))
     (when-not (every? (comp (partial = first-list-count) count second) path-lists)
-      (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-               :message "All HT Analysis Path Lists must have the same number of paths."}))))
+      (throw+ {:type :clojure-commons.exception/illegal-argument
+               :error "All HT Analysis Path Lists must have the same number of paths."}))))
 
 (defn- get-path-list-contents
   [user path]
@@ -97,12 +97,12 @@
    (catch [:status 500] {:keys [body]}
      (log/error (:throwable &throw-context) "job submission failed")
      (log/error (slurp body))
-     (throw+ {:error_code ce/ERR_REQUEST_FAILED
-              :message    "Could get file contents of path list input"}))
+     (throw+ {:type :clojure-commons.exception/request-failed
+              :error    "Could get file contents of path list input"}))
    (catch Object _
      (log/error (:throwable &throw-context) "job submission failed")
-     (throw+ {:error_code ce/ERR_REQUEST_FAILED
-              :message    "Could get file contents of path list input"}))))
+     (throw+ {:type :clojure-commons.exception/request-failed
+              :error    "Could get file contents of path list input"}))))
 
 (defn- get-path-list-contents-map
   [user paths]
@@ -113,6 +113,7 @@
   (let [output-dir (ft/build-result-folder-path submission)]
     (try+
      (data-info/get-file-stats user [output-dir])
+     ; FIXME Update this when data-info's exception handling is updated
      (catch [:status 500] {:keys [body]}
        (if (= (:error_code (service/parse-json body)) ce/ERR_DOES_NOT_EXIST)
          (data-info/create-directory user output-dir)

--- a/services/metadactyl-clj/src/metadactyl/service/apps/jobs/submissions.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps/jobs/submissions.clj
@@ -28,7 +28,7 @@
    (data-info/get-file-stats user paths)
    (catch Object _
      (log/error (:throwable &throw-context) "job submission failed")
-     (throw+ {:type :clojure-commons.exception/request-failed
+     (throw+ {:type  :clojure-commons.exception/request-failed
               :error "Could not lookup info types of inputs"}))))
 
 (defn- load-path-list-stats
@@ -54,20 +54,20 @@
 (defn- max-path-list-size-exceeded
   [max-size path actual-size]
   (throw+
-   {:type       :clojure-commons.exception/illegal-argument
-    :error      (str "HT Analysis Path List file exceeds maximum size of " max-size " bytes.")
-    :path path
-    :file-size actual-size}))
+    {:type      :clojure-commons.exception/illegal-argument
+     :error     (str "HT Analysis Path List file exceeds maximum size of " max-size " bytes.")
+     :path      path
+     :file-size actual-size}))
 
 (defn- max-batch-paths-exceeded
   [max-paths first-list-path first-list-count]
   (throw+
-   {:type :clojure-commons.exception/illegal-argument
-    :error    (str "The HT Analysis Path List exceeds the maximum of "
-                   max-paths
-                   " allowed paths.")
-    :path       first-list-path
-    :path-count first-list-count}))
+    {:type       :clojure-commons.exception/illegal-argument
+     :error      (str "The HT Analysis Path List exceeds the maximum of "
+                      max-paths
+                      " allowed paths.")
+     :path       first-list-path
+     :path-count first-list-count}))
 
 (defn- validate-path-list-stats
   [{path :path actual-size :file-size}]
@@ -77,7 +77,7 @@
 (defn- validate-ht-params
   [ht-params]
   (when (some (comp (partial = ap/param-multi-input-type) :type) ht-params)
-    (throw+ {:type :clojure-commons.exception/illegal-argument
+    (throw+ {:type  :clojure-commons.exception/illegal-argument
              :error "HT Analysis Path List files are not supported in multi-file inputs."})))
 
 (defn- validate-path-lists
@@ -87,7 +87,7 @@
     (when (> first-list-count (config/path-list-max-paths))
       (max-batch-paths-exceeded (config/path-list-max-paths) first-list-path first-list-count))
     (when-not (every? (comp (partial = first-list-count) count second) path-lists)
-      (throw+ {:type :clojure-commons.exception/illegal-argument
+      (throw+ {:type  :clojure-commons.exception/illegal-argument
                :error "All HT Analysis Path Lists must have the same number of paths."}))))
 
 (defn- get-path-list-contents
@@ -97,12 +97,12 @@
    (catch [:status 500] {:keys [body]}
      (log/error (:throwable &throw-context) "job submission failed")
      (log/error (slurp body))
-     (throw+ {:type :clojure-commons.exception/request-failed
-              :error    "Could get file contents of path list input"}))
+     (throw+ {:type  :clojure-commons.exception/request-failed
+              :error "Could not get file contents of path list input"}))
    (catch Object _
      (log/error (:throwable &throw-context) "job submission failed")
-     (throw+ {:type :clojure-commons.exception/request-failed
-              :error    "Could get file contents of path list input"}))))
+     (throw+ {:type  :clojure-commons.exception/request-failed
+              :error "Could not get file contents of path list input"}))))
 
 (defn- get-path-list-contents-map
   [user paths]

--- a/services/metadactyl-clj/src/metadactyl/service/oauth.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/oauth.clj
@@ -20,8 +20,8 @@
   [api-name]
   (if-let [server-info-fn (server-info-fn-for (keyword api-name))]
     (server-info-fn)
-    (throw+ {:type :clojure-commons.exception/bad-request-field
-             :error     (str "unknown API name: " api-name)})))
+    (throw+ {:type  :clojure-commons.exception/bad-request-field
+             :error (str "unknown API name: " api-name)})))
 
 (defn get-access-token
   "Receives an OAuth authorization code and obtains an access token."

--- a/services/metadactyl-clj/src/metadactyl/service/oauth.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/oauth.clj
@@ -3,12 +3,8 @@
   (:use [metadactyl.user :only [current-user]]
         [slingshot.slingshot :only [throw+]])
   (:require [authy.core :as authy]
-            [cemerick.url :as curl]
-            [clj-http.client :as http]
-            [clojure-commons.error-codes :as ce]
             [metadactyl.persistence.oauth :as op]
-            [metadactyl.util.config :as config]
-            [metadactyl.util.service :as service]))
+            [metadactyl.util.config :as config]))
 
 (defn- build-authy-server-info
   "Builds the server info to pass to authy."
@@ -24,8 +20,8 @@
   [api-name]
   (if-let [server-info-fn (server-info-fn-for (keyword api-name))]
     (server-info-fn)
-    (throw+ {:error_code ce/ERR_BAD_REQUEST
-             :reason     (str "unknown API name: " api-name)})))
+    (throw+ {:type :clojure-commons.exception/bad-request-field
+             :error     (str "unknown API name: " api-name)})))
 
 (defn get-access-token
   "Receives an OAuth authorization code and obtains an access token."
@@ -35,4 +31,4 @@
         state-info     (op/retrieve-authorization-request-state state username)
         token-callback (partial op/store-access-token api-name username)]
     (authy/get-access-token (build-authy-server-info server-info token-callback) code)
-    (service/success-response {:state_info state-info})))
+    {:state_info state-info}))

--- a/services/metadactyl-clj/src/metadactyl/service/workspace.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/workspace.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.service.workspace
   (:use [korma.db :only [transaction]])
-  (:require [metadactyl.persistence.workspace :as wp]
-            [metadactyl.util.service :as service]))
+  (:require [metadactyl.persistence.workspace :as wp]))
 
 (defn get-workspace
   [{:keys [username]}]

--- a/services/metadactyl-clj/src/metadactyl/tools.clj
+++ b/services/metadactyl-clj/src/metadactyl/tools.clj
@@ -10,9 +10,7 @@
         [clojure.string :only [upper-case]]
         [korma.core :exclude [update]]
         [korma.db :only [transaction]])
-  (:require [clojure-commons.error-codes :as cc-errs]
-            [metadactyl.persistence.app-metadata :as persistence]
-            [metadactyl.util.service :as service]))
+  (:require [metadactyl.persistence.app-metadata :as persistence]))
 
 (defn- add-search-where-clauses
   "Adds where clauses to a base tool search query to restrict results to tools that contain the
@@ -61,18 +59,16 @@
 (defn search-tools
   "Obtains a listing of tools for the tool search service."
   [params]
-  (service/success-response
-    {:tools
+  {:tools
      (map remove-nil-vals
-       (select (tool-listing-base-query params)))}))
+       (select (tool-listing-base-query params)))})
 
 (defn get-tool
   "Obtains a tool by ID."
   [tool-id]
   (->> (first (select (tool-listing-base-query) (where {:tools.id tool-id})))
        (assert-not-nil [:tool-id tool-id])
-       remove-nil-vals
-       service/success-response))
+       remove-nil-vals))
 
 (defn get-tools-by-id
   "Obtains a listing of tools for the given list of IDs."
@@ -93,7 +89,7 @@
   [{:keys [tools]}]
   (transaction
     (let [tool-ids (doall (map add-new-tool tools))]
-      (service/success-response {:tool_ids tool-ids}))))
+      {:tool_ids tool-ids})))
 
 (defn update-tool
   [{:keys [id] :as tool}]

--- a/services/metadactyl-clj/src/metadactyl/transformers.clj
+++ b/services/metadactyl-clj/src/metadactyl/transformers.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.transformers
   (:use [clojure.java.io :only [reader]])
-  (:require [cheshire.core :as cheshire]
-            [clojure.tools.logging :as log]))
+  (:require [cheshire.core :as cheshire]))
 
 (defn add-username-to-json
   "Adds the name of the currently authenticated user to a JSON object in the

--- a/services/metadactyl-clj/src/metadactyl/translations/app_metadata/external_to_internal.clj
+++ b/services/metadactyl-clj/src/metadactyl/translations/app_metadata/external_to_internal.clj
@@ -1,8 +1,6 @@
 (ns metadactyl.translations.app-metadata.external-to-internal
   (:use [metadactyl.translations.app-metadata.util]
-        [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as ce]
-            [clojure.tools.logging :as log]))
+        [slingshot.slingshot :only [throw+]]))
 
 (defn- mark-default-selection-item
   [default-value item]

--- a/services/metadactyl-clj/src/metadactyl/translations/app_metadata/internal_to_external.clj
+++ b/services/metadactyl-clj/src/metadactyl/translations/app_metadata/internal_to_external.clj
@@ -2,9 +2,7 @@
   (:use [metadactyl.translations.app-metadata.util]
         [metadactyl.metadata.reference-genomes :only [get-reference-genomes-by-id]]
         [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as ce]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]))
+  (:require [clojure.string :as string]))
 
 (defn validators-from-rules
   "Converts a list of rules from the internal JSON format to a list of validators for the

--- a/services/metadactyl-clj/src/metadactyl/translations/app_metadata/util.clj
+++ b/services/metadactyl-clj/src/metadactyl/translations/app_metadata/util.clj
@@ -1,7 +1,6 @@
 (ns metadactyl.translations.app-metadata.util
   (:use [slingshot.slingshot :only [throw+]])
-  (:require [clojure.set :as set]
-            [clojure-commons.error-codes :as ce]))
+  (:require [clojure.set :as set]))
 
 (def input-property-types
   #{"Input" "FileInput" "FolderInput" "MultiFileSelector"})

--- a/services/metadactyl-clj/src/metadactyl/user.clj
+++ b/services/metadactyl-clj/src/metadactyl/user.clj
@@ -3,9 +3,7 @@
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as common-errors]
-            [metadactyl.clients.iplant-groups :as ipg]
-            [metadactyl.util.service :as service]))
+            [metadactyl.clients.iplant-groups :as ipg]))
 
 (def
   ^{:doc "The authenticated user or nil if the service is unsecured."
@@ -17,9 +15,9 @@
   (log/debug user-attributes)
   (let [uid (user-attributes :user)]
     (if (empty? uid)
-      (throw+ {:error_code common-errors/ERR_NOT_AUTHORIZED,
-               :user (dissoc user-attributes :password),
-               :message "Invalid user credentials provided."}))
+      (throw+ {:type :clojure-commons.exception/bad-request-field
+               :error "Invalid user credentials provided."
+               :user (dissoc user-attributes :password)}))
     (-> (select-keys user-attributes [:password :email :first-name :last-name])
         (assoc :username (str uid "@" (uid-domain))
           :shortUsername uid))))
@@ -35,8 +33,8 @@
    of org.iplantc.authn.user.User that is built from the user attributes found
    in the given params map, then passes request to the given handler."
   [handler & [opts]]
-  (fn [{uri :uri :as request}]
-    (common-errors/trap uri #(with-user [(:params request)] (handler request)))))
+  (fn [request]
+    (with-user [(:params request)] (handler request))))
 
 (defn load-user-as-user
   "Loads information for the user with the given username, as another username."

--- a/services/metadactyl-clj/src/metadactyl/user.clj
+++ b/services/metadactyl-clj/src/metadactyl/user.clj
@@ -15,9 +15,9 @@
   (log/debug user-attributes)
   (let [uid (user-attributes :user)]
     (if (empty? uid)
-      (throw+ {:type :clojure-commons.exception/bad-request-field
+      (throw+ {:type :clojure-commons.exception/not-authorized
                :error "Invalid user credentials provided."
-               :user (dissoc user-attributes :password)}))
+               :user (select-keys user-attributes [:username :shortUsername :first-name :last-name :email])}))
     (-> (select-keys user-attributes [:password :email :first-name :last-name])
         (assoc :username (str uid "@" (uid-domain))
           :shortUsername uid))))

--- a/services/metadactyl-clj/src/metadactyl/util/assertions.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/assertions.clj
@@ -11,7 +11,7 @@
   [[id-field id] & body]
   `(let [res# (do ~@body)]
      (if (nil? res#)
-       (throw+ {:type :clojure-commons.exception/not-found
-                :error (str "The item with the following ID could not be found: " ~id)
+       (throw+ {:type     :clojure-commons.exception/not-found
+                :error    (str "The item with the following ID could not be found: " ~id)
                 ~id-field (str ~id)})
        res#)))

--- a/services/metadactyl-clj/src/metadactyl/util/assertions.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/assertions.clj
@@ -1,8 +1,6 @@
 (ns metadactyl.util.assertions
   "Assertions for metadactyl services."
-  (:use [slingshot.slingshot :only [throw+]])
-  (:require [clojure.string :as string]
-            [clojure-commons.error-codes :as ce]))
+  (:use [slingshot.slingshot :only [throw+]]))
 
 (defmacro assert-not-nil
   "Throws an exception if the result of a group of expressions is nil.
@@ -13,18 +11,7 @@
   [[id-field id] & body]
   `(let [res# (do ~@body)]
      (if (nil? res#)
-       (throw+ {:error_code ce/ERR_NOT_FOUND
-                ~id-field   ~id})
-       res#)))
-
-(defmacro assert-not-blank
-  "Throws an exception if the result of a group of expresssions is blank.
-
-   Parameters:
-     field - the name of the field whose value is blank."
-  [[field] & body]
-  `(let [res# (do ~@body)]
-     (if (string/blank? res#)
-       (throw+ {:error_code ce/ERR_ILLEGAL_ARGUMENT
-                :field      ~field})
+       (throw+ {:type :clojure-commons.exception/not-found
+                :error (str "The item with the following ID could not be found: " ~id)
+                ~id-field (str ~id)})
        res#)))

--- a/services/metadactyl-clj/src/metadactyl/util/coercions.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/coercions.clj
@@ -27,5 +27,6 @@
   [schema value]
   (let [result (coerce schema value)]
     (if (su/error? result)
-      (throw+ {:type :ring.swagger.schema/validation :error (:error result)})
+      (throw+ {:type  :ring.swagger.schema/validation
+               :error (:error result)})
       result)))

--- a/services/metadactyl-clj/src/metadactyl/util/config.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/config.clj
@@ -3,8 +3,6 @@
   (:require [cemerick.url :as curl]
             [cheshire.core :as cheshire]
             [clojure-commons.config :as cc]
-            [clojure-commons.error-codes :as ce]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [common-cfg.cfg :as cfg]))
 
@@ -275,7 +273,7 @@
   "Validates the configuration settings after they've been loaded."
   []
   (when-not (cc/validate-config configs config-valid)
-    (throw+ {:error_code ce/ERR_CONFIG_INVALID})))
+    (throw+ {:type :clojure-commons.exception/invalid-configuration})))
 
 (defn load-config-from-file
   "Loads the configuration settings from a file."

--- a/services/metadactyl-clj/src/metadactyl/util/params.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/params.clj
@@ -1,8 +1,7 @@
 (ns metadactyl.util.params
   (:use [clojure.string :only [lower-case]]
         [metadactyl.util.conversions]
-        [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as error-codes]))
+        [slingshot.slingshot :only [throw+]]))
 
 (defn- blank?
   "Returns true if the argument is nil or a blank string."
@@ -16,7 +15,7 @@
   [ks m]
   (let [v (first (remove blank? (map m ks)))]
     (when (blank? v)
-      (throw+ {:error_code error-codes/ERR_BAD_OR_MISSING_FIELD
+      (throw+ {:type :clojure-commons.exception/bad-request-field
                :params ks}))
     v))
 

--- a/services/metadactyl-clj/src/metadactyl/util/params.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/params.clj
@@ -15,7 +15,7 @@
   [ks m]
   (let [v (first (remove blank? (map m ks)))]
     (when (blank? v)
-      (throw+ {:type :clojure-commons.exception/bad-request-field
+      (throw+ {:type   :clojure-commons.exception/bad-request-field
                :params ks}))
     v))
 

--- a/services/metadactyl-clj/src/metadactyl/util/pgp.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/pgp.clj
@@ -4,7 +4,6 @@
             [clj-pgp.keyring :as keyring]
             [clj-pgp.message :as pgp-msg]
             [clojure.java.io :as io]
-            [clojure-commons.error-codes :as ce]
             [metadactyl.util.config :as config]))
 
 (def ^:private keyring
@@ -30,5 +29,5 @@
   [bs]
   (if-let [private-key (get-private-key)]
     (String. (pgp-msg/decrypt bs private-key))
-    (throw+ {:error_code ce/ERR_CONFIG_INVALID
-             :message    "unable to unlock the private encryption key"})))
+    (throw+ {:type  :clojure-commons.exception/invalid-configuration
+             :error "unable to unlock the private encryption key"})))

--- a/services/metadactyl-clj/src/metadactyl/util/service.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/service.clj
@@ -1,45 +1,17 @@
 (ns metadactyl.util.service
   (:use [clojure.java.io :only [reader]]
         [ring.util.response :only [charset]]
+        [ring.util.http-response :only [ok]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [cheshire.core :as cheshire]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
             [clojure-commons.assertions :as ca]
-            [clojure-commons.error-codes :as ce]
             [metadactyl.util.coercions :as mc]))
-
-(def ^:private default-content-type-header
-  {"Content-Type" "application/json; charset=utf-8"})
-
-(defn success-response
-  ([map]
-     (charset
-      {:status       200
-       :body         map
-       :headers default-content-type-header}
-      "UTF-8"))
-  ([]
-     (success-response nil)))
-
-(defn not-found-response
-  [msg]
-  (charset
-   {:status 404
-    :body   msg}
-   "UTF-8"))
 
 (defn unrecognized-path-response
   "Builds the response to send for an unrecognized service path."
   []
   (let [msg "unrecognized service path"]
     (cheshire/encode {:reason msg})))
-
-(defn prepare-forwarded-request
-  "Prepares a request to be forwarded to a remote service."
-  [request body]
-  {:headers (dissoc (:headers request) "content-length")
-   :body body})
 
 (defn parse-json
   "Parses a JSON request body."
@@ -49,25 +21,19 @@
       (cheshire/decode body true)
       (cheshire/decode-stream (reader body) true))
     (catch Exception e
-      (throw+ {:error_code ce/ERR_INVALID_JSON
-               :detail     (str e)}))))
-
-(defn trap
-  "Traps a service call, automatically calling success-response on the result."
-  [action func & args]
-  (ce/trap action #(success-response (apply func args))))
+      (throw+ {:type :clojure-commons.exception/invalid-json
+               :error     (str e)}))))
 
 (defn coerced-trap
   "Traps a service call, automatically coercing the output and calling success-response
    on the result."
-  [action schema func & args]
-  (ce/trap action #(success-response (mc/coerce! schema (apply func args)))))
+  [_ schema func & args]
+  (ok (mc/coerce! schema (apply func args))))
 
 (def not-found ca/not-found)
 (def not-owner ca/not-owner)
 (def not-unique ca/not-unique)
 (def bad-request ca/bad-request)
 (def assert-found ca/assert-found)
-(def assert-not-found ca/assert-not-found)
 (def assert-valid ca/assert-valid)
 (def request-failure ca/request-failure)

--- a/services/metadactyl-clj/src/metadactyl/util/service.clj
+++ b/services/metadactyl-clj/src/metadactyl/util/service.clj
@@ -4,8 +4,7 @@
         [ring.util.http-response :only [ok]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [cheshire.core :as cheshire]
-            [clojure-commons.assertions :as ca]
-            [metadactyl.util.coercions :as mc]))
+            [clojure-commons.assertions :as ca]))
 
 (defn unrecognized-path-response
   "Builds the response to send for an unrecognized service path."
@@ -21,14 +20,8 @@
       (cheshire/decode body true)
       (cheshire/decode-stream (reader body) true))
     (catch Exception e
-      (throw+ {:type :clojure-commons.exception/invalid-json
-               :error     (str e)}))))
-
-(defn coerced-trap
-  "Traps a service call, automatically coercing the output and calling success-response
-   on the result."
-  [_ schema func & args]
-  (ok (mc/coerce! schema (apply func args))))
+      (throw+ {:type  :clojure-commons.exception/invalid-json
+               :error (str e)}))))
 
 (def not-found ca/not-found)
 (def not-owner ca/not-owner)

--- a/services/metadactyl-clj/src/metadactyl/validation.clj
+++ b/services/metadactyl-clj/src/metadactyl/validation.clj
@@ -5,8 +5,7 @@
         [clojure.string :only [blank?]]
         [korma.core :exclude [update]]
         [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as cc-errs]
-            [clojure-commons.validators :as validators]
+  (:require [clojure-commons.validators :as validators]
             [metadactyl.persistence.app-metadata :as persistence]))
 
 (defn missing-json-field-exception
@@ -188,16 +187,16 @@
   [tool]
   (let [existing-tool (first (select tools (where (select-keys tool [:name :location]))))]
     (when existing-tool
-      (throw+ {:error_code cc-errs/ERR_EXISTS
-               :message    "A Tool with that name and location already exists."
-               :tool       tool}))))
+      (throw+ {:type   :clojure-commons.exception/exists
+               :error  "A Tool with that name and location already exists."
+               :tool tool}))))
 
 (defn- verify-app-not-public
   "Verifies that an app has not been made public."
   [app]
   (if (:is_public app)
-    (throw+ {:error_code cc-errs/ERR_NOT_WRITEABLE,
-             :message (str "Workflow, " (:id app) ", is public and may not be edited")})))
+    (throw+ {:type :clojure-commons.exception/not-writeable
+             :error (str "Workflow, " (:id app) ", is public and may not be edited")})))
 
 (defn verify-app-ownership
   "Verifies that a user owns the app that is being edited."
@@ -205,9 +204,9 @@
      (verify-app-ownership current-user app))
   ([user app]
      (when-not (validators/user-owns-app? user app)
-       (throw+ {:error_code cc-errs/ERR_NOT_OWNER,
-                :username   (:username user),
-                :message    (str (:shortUsername user) " does not own app " (:id app))}))))
+       (throw+ {:type   :clojure-commons.exception/not-owner
+                :error  (str (:shortUsername user) " does not own app " (:id app))
+                :username (:username user),}))))
 
 (defn verify-app-editable
   "Verifies that the app is allowed to be edited by the current user."
@@ -221,8 +220,8 @@
   "Verifies that an external app step in a pipeline has all of the required fields."
   [step-number {external-app-id :external_app_id}]
   (when (blank? external-app-id)
-    (throw+ {:error_code cc-errs/ERR_BAD_OR_MISSING_FIELD
-             :message (str "pipeline step " step-number " contians neither a task ID nor an "
+    (throw+ {:type :clojure-commons.exception/missing-request-field
+             :error (str "pipeline step " step-number " contians neither a task ID nor an "
                            "external app ID")})))
 
 (defn validate-parameter
@@ -236,27 +235,27 @@
   (when (and (contains? persistence/param-output-types param-type)
              (blank? default-value)
              (or (not visible) implicit))
-    (throw+ {:error_code cc-errs/ERR_BAD_OR_MISSING_FIELD
-             :message    "Hidden output parameters must define a default value."
-             :parameter  parameter})))
+    (throw+ {:type   :clojure-commons.exception/missing-request-field
+             :error  "Hidden output parameters must define a default value."
+             :parameter parameter})))
 
 (defn validate-pipeline
   "Verifies that a pipeline contains at least 2 steps and at least 1 input->ouput mapping."
   [{:keys [steps mappings]}]
   (when (< (count steps) 2)
-    (throw+ {:error_code cc-errs/ERR_BAD_OR_MISSING_FIELD
-             :message    "Cannot save a workflow with less than 2 steps defined."
-             :steps      steps}))
+    (throw+ {:type   :clojure-commons.exception/missing-request-field
+             :error  "Cannot save a workflow with less than 2 steps defined."
+             :steps steps}))
   (when (< (count mappings) 1)
-    (throw+ {:error_code cc-errs/ERR_BAD_OR_MISSING_FIELD
-             :message    "Cannot save a workflow without input->output mappings defined."
-             :mappings   mappings})))
+    (throw+ {:type  :clojure-commons.exception/missing-request-field
+             :error "Cannot save a workflow without input->output mappings defined."
+             :mappings mappings})))
 
 (defn get-valid-user-id
   "Gets the user ID for the given username, or throws an error if that username is not found."
   [username]
   (let [user-id (get-existing-user-id username)]
     (when (nil? user-id)
-      (throw+ {:error_code cc-errs/ERR_BAD_REQUEST
-               :reason     (str "No user found for username " username)}))
+      (throw+ {:type  :clojure-commons.exception/bad-request-field
+               :error (str "No user found for username " username)}))
     user-id))

--- a/services/metadactyl-clj/src/metadactyl/validation.clj
+++ b/services/metadactyl-clj/src/metadactyl/validation.clj
@@ -187,15 +187,15 @@
   [tool]
   (let [existing-tool (first (select tools (where (select-keys tool [:name :location]))))]
     (when existing-tool
-      (throw+ {:type   :clojure-commons.exception/exists
-               :error  "A Tool with that name and location already exists."
-               :tool tool}))))
+      (throw+ {:type  :clojure-commons.exception/exists
+               :error "A Tool with that name and location already exists."
+               :tool  tool}))))
 
 (defn- verify-app-not-public
   "Verifies that an app has not been made public."
   [app]
   (if (:is_public app)
-    (throw+ {:type :clojure-commons.exception/not-writeable
+    (throw+ {:type  :clojure-commons.exception/not-writeable
              :error (str "Workflow, " (:id app) ", is public and may not be edited")})))
 
 (defn verify-app-ownership
@@ -204,8 +204,8 @@
      (verify-app-ownership current-user app))
   ([user app]
      (when-not (validators/user-owns-app? user app)
-       (throw+ {:type   :clojure-commons.exception/not-owner
-                :error  (str (:shortUsername user) " does not own app " (:id app))
+       (throw+ {:type     :clojure-commons.exception/not-owner
+                :error    (str (:shortUsername user) " does not own app " (:id app))
                 :username (:username user),}))))
 
 (defn verify-app-editable
@@ -220,9 +220,9 @@
   "Verifies that an external app step in a pipeline has all of the required fields."
   [step-number {external-app-id :external_app_id}]
   (when (blank? external-app-id)
-    (throw+ {:type :clojure-commons.exception/missing-request-field
+    (throw+ {:type  :clojure-commons.exception/missing-request-field
              :error (str "pipeline step " step-number " contians neither a task ID nor an "
-                           "external app ID")})))
+                         "external app ID")})))
 
 (defn validate-parameter
   "Ensures that hidden output parameters have a filename defined."
@@ -235,20 +235,20 @@
   (when (and (contains? persistence/param-output-types param-type)
              (blank? default-value)
              (or (not visible) implicit))
-    (throw+ {:type   :clojure-commons.exception/missing-request-field
-             :error  "Hidden output parameters must define a default value."
+    (throw+ {:type      :clojure-commons.exception/missing-request-field
+             :error     "Hidden output parameters must define a default value."
              :parameter parameter})))
 
 (defn validate-pipeline
   "Verifies that a pipeline contains at least 2 steps and at least 1 input->ouput mapping."
   [{:keys [steps mappings]}]
   (when (< (count steps) 2)
-    (throw+ {:type   :clojure-commons.exception/missing-request-field
-             :error  "Cannot save a workflow with less than 2 steps defined."
+    (throw+ {:type  :clojure-commons.exception/missing-request-field
+             :error "Cannot save a workflow with less than 2 steps defined."
              :steps steps}))
   (when (< (count mappings) 1)
-    (throw+ {:type  :clojure-commons.exception/missing-request-field
-             :error "Cannot save a workflow without input->output mappings defined."
+    (throw+ {:type     :clojure-commons.exception/missing-request-field
+             :error    "Cannot save a workflow without input->output mappings defined."
              :mappings mappings})))
 
 (defn get-valid-user-id

--- a/services/metadactyl-clj/src/metadactyl/workspace.clj
+++ b/services/metadactyl-clj/src/metadactyl/workspace.clj
@@ -2,8 +2,7 @@
   (:use [kameleon.queries]
         [korma.core :exclude [update]]
         [metadactyl.user :only [current-user]]
-        [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.error-codes :as cc-errs]))
+        [slingshot.slingshot :only [throw+]]))
 
 (defn get-workspace
   "Gets a workspace database entry for the given username or the current user."
@@ -12,9 +11,9 @@
   ([username]
      (if-let [workspace (fetch-workspace-by-user-id (get-existing-user-id username))]
        workspace
-       (throw+ {:error_code cc-errs/ERR_NOT_FOUND,
-                :username username,
-                :message  "Workspace for user not found."}))))
+       (throw+ {:type    :clojure-commons.exception/not-found
+                :message "Workspace for user not found."
+                :username username}))))
 
 (defn get-optional-workspace
   "Gets a workspace database entry for the given username if a username is provided."

--- a/services/metadactyl-clj/src/metadactyl/workspace.clj
+++ b/services/metadactyl-clj/src/metadactyl/workspace.clj
@@ -11,8 +11,8 @@
   ([username]
      (if-let [workspace (fetch-workspace-by-user-id (get-existing-user-id username))]
        workspace
-       (throw+ {:type    :clojure-commons.exception/not-found
-                :message "Workspace for user not found."
+       (throw+ {:type     :clojure-commons.exception/not-found
+                :message  "Workspace for user not found."
                 :username username}))))
 
 (defn get-optional-workspace

--- a/services/metadata/src/metadata/routes.clj
+++ b/services/metadata/src/metadata/routes.clj
@@ -1,7 +1,7 @@
 (ns metadata.routes
   (:use [clojure-commons.lcase-params :only [wrap-lcase-params]]
         [clojure-commons.query-params :only [wrap-query-params]]
-        [service-logging.middleware :only [log-validation-errors]]
+        [service-logging.middleware :only [log-validation-errors add-user-to-context]]
         [common-swagger-api.schema])
   (:require [metadata.routes.avus :as avu-routes]
             [metadata.routes.comments :as comment-routes]
@@ -11,9 +11,7 @@
             [metadata.routes.templates :as template-routes]
             [metadata.util.config :as config]
             [metadata.util.service :as service]
-            [ring.middleware.keyword-params :as params]
-            [schema.core :as s]
-            [service-logging.thread-context :as tc]))
+            [ring.middleware.keyword-params :as params]))
 
 (defapi app
   (swagger-ui config/docs-uri)
@@ -32,7 +30,7 @@
             {:name "template-info", :description "Template Information"}
             {:name "template-administration", :description "Template Administration"}]})
   (middlewares
-    [tc/add-user-to-context
+    [add-user-to-context
      wrap-query-params
      wrap-lcase-params
      params/wrap-keyword-params


### PR DESCRIPTION
This PR contains the updates for metadactyl's Access logging and exception handling.

Some of the changes that have been made here still need to be propagated back into Donkey. I'd like those changes to be part of this PR, but I do not want to commit them until the first batch of metadactyl-only changes have been settled on.

All exceptions are now thrown as a map containing [:type, :error, and
optional keys]. The optional keys are placed into the exception response
automatically (not nested in a ":fields" key).

Routes are the only functions which should return success responses.
All non-route functions have been cleansed of returning any kind of Ring
response.

Throwables and exceptions are no longer passed to the response logging
middlewares through the response map. The response logging middlewares
will only be executed if all is successful. It is now the responsibility
of the exception handlers to log response errors.