### PR TITLE
Added logging context for external svc integration

### DIFF
--- a/libs/mescal/project.clj
+++ b/libs/mescal/project.clj
@@ -11,4 +11,5 @@
                  [medley "0.5.3"]
                  [org.iplantc/authy "5.0.0"]
                  [org.iplantc/clojure-commons "5.0.0"]
+                 [org.iplantc/service-logging "5.0.0"]
                  [slingshot "0.10.3"]])

--- a/libs/mescal/src/mescal/agave_v2.clj
+++ b/libs/mescal/src/mescal/agave_v2.clj
@@ -1,6 +1,7 @@
 (ns mescal.agave-v2
   (:use [medley.core :only [remove-vals take-upto]]
-        [slingshot.slingshot :only [try+ throw+]])
+        [slingshot.slingshot :only [try+ throw+]]
+        [service-logging.thread-context :only [set-ext-svc-tag!]])
   (:require [authy.core :as authy]
             [cemerick.url :as curl]
             [clj-http.client :as http]
@@ -68,12 +69,14 @@
 
 (defn agave-get
   [token-info-fn timeout url & [{:keys [page-len]}]]
+  (set-ext-svc-tag! "agave")
   (if page-len
     (agave-get-paged token-info-fn timeout page-len url)
     (agave-get* token-info-fn timeout url)))
 
 (defn agave-post
   [token-info-fn timeout url body]
+  (set-ext-svc-tag! "agave")
   (with-refresh [token-info-fn timeout]
     ((comp :result :body)
      (http/post (str url)

--- a/libs/service-logging/src/service_logging/middleware.clj
+++ b/libs/service-logging/src/service_logging/middleware.clj
@@ -50,9 +50,10 @@
      (tc/with-logging-context {:response (cheshire/encode (clean-response (assoc response
                                                                            :uri uri
                                                                            :request-method request-method)))}
-                              (log/log 'AccessLogger level throwable (str method " " uri)))))
+                              (log/log 'AccessLogger level throwable (str method " " uri))
+                              (tc/clear-ext-svc-tag!))))
   ([request response]
-    (log-response :info nil request response))
+   (log-response :info nil request response))
   ([level request response]
    (log-response level nil request response)))
 

--- a/libs/service-logging/src/service_logging/thread_context.clj
+++ b/libs/service-logging/src/service_logging/thread_context.clj
@@ -15,6 +15,20 @@
   []
   (MDC/clear))
 
+(defn set-ext-svc-tag!
+  "Sets a value in the logging context which communicates the the operations in the current context
+   are from the designated external service.
+
+   After this key is set, it must be explicitly removed from the logging context when no longer
+   needed. This can be accomplished with 'clear-ext-svc-tag!'."
+  [tag]
+  (MDC/put "ext_service" tag))
+
+(defn clear-ext-svc-tag!
+  "Clears the external service tag from the logging context."
+  []
+  (MDC/remove "ext_service"))
+
 ;; With thanks to https://github.com/vaughnd/clojure-example-logback-integration/
 (defmacro with-logging-context
   "Use this to add a map to any logging wrapped in the macro. Macro can be nested.

--- a/services/metadactyl-clj/src/metadactyl/service/apps.clj
+++ b/services/metadactyl-clj/src/metadactyl/service/apps.clj
@@ -1,7 +1,8 @@
 (ns metadactyl.service.apps
   (:use [kameleon.uuids :only [uuidify]]
         [korma.db :only [transaction]]
-        [slingshot.slingshot :only [try+ throw+]])
+        [slingshot.slingshot :only [try+ throw+]]
+        [service-logging.thread-context :only [clear-ext-svc-tag!]])
   (:require [cemerick.url :as curl]
             [clojure.tools.logging :as log]
             [mescal.de :as agave]
@@ -238,7 +239,9 @@
    (log/info "synchronizing the job status for" id)
    (transaction (jobs/sync-job-status (get-apps-client-for-username username) job))
    (catch Object _
-     (log/error (:throwable &throw-context) "unable to sync the job status for job" id))))
+     (log/error (:throwable &throw-context) "unable to sync the job status for job" id))
+   (finally
+     (clear-ext-svc-tag!))))
 
 (defn sync-job-statuses
   []


### PR DESCRIPTION
Specifically, needed to annotate agave interactions with information for
metrics.

CORE-7057

This has been tested locally, but has not been tested with actual job submissions.