### PR TITLE
Clear log context

### DIFF
--- a/libs/service-logging/src/service_logging/middleware.clj
+++ b/libs/service-logging/src/service_logging/middleware.clj
@@ -61,6 +61,16 @@
   (tc/with-logging-context {:exception (cheshire/encode exception)}
                            (log-response :error throwable request response)))
 
+(defn clean-context
+  "Middleware which ensures that the logging context will be restored to its original
+   state prior to the request.
+
+   This middleware must be the first middleware in the chain of execution. For example,
+   if used in the thread-first macro, it must be the last middleware."
+  [handler]
+  (fn [request]
+    (tc/with-logging-context {} (handler request))))
+
 (defn wrap-logging
   "Logs incoming requests and their responses with the 'AccessLogger' logger.
 

--- a/services/Donkey/src/donkey/core.clj
+++ b/services/Donkey/src/donkey/core.clj
@@ -3,7 +3,7 @@
   (:use [clojure.java.io :only [file]]
         [clojure-commons.lcase-params :only [wrap-lcase-params]]
         [clojure-commons.query-params :only [wrap-query-params]]
-        [service-logging.middleware :only [wrap-logging]]
+        [service-logging.middleware :only [wrap-logging clean-context]]
         [compojure.core]
         [compojure.api.middleware :only [wrap-exceptions]]
         [ring.middleware.keyword-params]
@@ -223,7 +223,8 @@
   (-> (delayed-handler routes-fn)
       wrap-keyword-params
       wrap-lcase-params
-      wrap-query-params))
+      wrap-query-params
+      clean-context))
 
 (def app
   (site-handler donkey-routes))

--- a/services/NotificationAgent/project.clj
+++ b/services/NotificationAgent/project.clj
@@ -41,4 +41,5 @@
   :extra-classpath-dirs ["conf/test"]
   :aot [notification-agent.core]
   :main notification-agent.core
-  :uberjar-exclusions [#"(?i)[.]sf"])
+  :uberjar-exclusions [#"(?i)[.]sf"]
+  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/notificationagent-logging.xml"])

--- a/services/NotificationAgent/src/notification_agent/core.clj
+++ b/services/NotificationAgent/src/notification_agent/core.clj
@@ -3,7 +3,7 @@
   (:use [clojure.java.io :only [file]]
         [clojure-commons.lcase-params :only [wrap-lcase-params]]
         [clojure-commons.query-params :only [wrap-query-params]]
-        [service-logging.middleware :only [wrap-logging add-user-to-context]]
+        [service-logging.middleware :only [wrap-logging add-user-to-context clean-context]]
         [compojure.api.middleware :only [wrap-exceptions]]
         [compojure.core]
         [korma.db :only [transaction]]
@@ -171,7 +171,8 @@
       wrap-keyword-params
       wrap-lcase-params
       wrap-nested-params
-      wrap-query-params))
+      wrap-query-params
+      clean-context))
 
 (def app
   (site-handler notificationagent-routes))

--- a/services/iplant-groups/project.clj
+++ b/services/iplant-groups/project.clj
@@ -39,4 +39,5 @@
   :ring {:handler iplant_groups.routes/app
          :init    iplant_groups.core/init-service
          :port    31310}
-  :uberjar-exclusions [#"(?i)META-INF/[^/]*[.](SF|DSA|RSA)"])
+  :uberjar-exclusions [#"(?i)META-INF/[^/]*[.](SF|DSA|RSA)"]
+  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/iplant-groups-logging.xml"])

--- a/services/iplant-groups/src/iplant_groups/routes.clj
+++ b/services/iplant-groups/src/iplant_groups/routes.clj
@@ -1,5 +1,5 @@
 (ns iplant_groups.routes
-  (:use [service-logging.middleware :only [wrap-logging add-user-to-context]]
+  (:use [service-logging.middleware :only [wrap-logging add-user-to-context clean-context]]
         [clojure-commons.query-params :only [wrap-query-params]]
         [compojure.core :only [wrap-routes]]
         [common-swagger-api.schema]
@@ -24,14 +24,16 @@
            {:name "service-info", :description "Service Status Information"}
            {:name "subjects", :description "Subject Information"}]})
   (middlewares
-   [wrap-keyword-params
+   [clean-context
+    wrap-keyword-params
     wrap-query-params
    (wrap-routes wrap-logging)]
    (context* "/" []
     :tags ["service-info"]
     status-routes/status))
   (middlewares
-   [wrap-keyword-params
+   [clean-context
+    wrap-keyword-params
     wrap-query-params
     add-user-to-context
     wrap-logging]

--- a/services/metadactyl-clj/src/metadactyl/routes/api.clj
+++ b/services/metadactyl-clj/src/metadactyl/routes/api.clj
@@ -1,5 +1,5 @@
 (ns metadactyl.routes.api
-  (:use [service-logging.middleware :only [wrap-logging]]
+  (:use [service-logging.middleware :only [wrap-logging clean-context]]
         [compojure.core :only [wrap-routes]]
         [clojure-commons.query-params :only [wrap-query-params]]
         [common-swagger-api.schema]
@@ -56,7 +56,8 @@
             {:name "admin-reference-genomes", :description "Admin Reference Genome endpoints."}
             {:name "admin-tool-requests", :description "Admin Tool Request endpoints."}]})
   (middlewares
-    [wrap-keyword-params
+    [clean-context
+     wrap-keyword-params
      wrap-query-params
      (wrap-routes wrap-logging)]
     (context* "/" []
@@ -66,7 +67,8 @@
       :tags ["callbacks"]
       callback-routes/callbacks))
   (middlewares
-    [wrap-keyword-params
+    [clean-context
+     wrap-keyword-params
      wrap-query-params
      add-user-to-context
      store-current-user

--- a/services/metadata/project.clj
+++ b/services/metadata/project.clj
@@ -33,4 +33,5 @@
              ;; https://github.com/metosin/compojure-api/issues/135#issuecomment-121388539
              ;; https://github.com/metosin/compojure-api/issues/102
              :uberjar {:aot [#"metadata.(?!routes).*"]}}
-  :uberjar-exclusions [#".*[.]SF" #"LICENSE" #"NOTICE"])
+  :uberjar-exclusions [#".*[.]SF" #"LICENSE" #"NOTICE"]
+  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/metadata-logging.xml"])

--- a/services/metadata/src/metadata/routes.clj
+++ b/services/metadata/src/metadata/routes.clj
@@ -2,7 +2,7 @@
   (:use [clojure-commons.lcase-params :only [wrap-lcase-params]]
         [clojure-commons.query-params :only [wrap-query-params]]
         [compojure.core :only [wrap-routes]]
-        [service-logging.middleware :only [wrap-logging add-user-to-context]]
+        [service-logging.middleware :only [wrap-logging add-user-to-context clean-context]]
         [common-swagger-api.schema])
   (:require [metadata.routes.avus :as avu-routes]
             [metadata.routes.comments :as comment-routes]
@@ -32,7 +32,8 @@
             {:name "template-info", :description "Template Information"}
             {:name "template-administration", :description "Template Administration"}]})
   (middlewares
-    [wrap-query-params
+    [clean-context
+     wrap-query-params
      wrap-lcase-params
      params/wrap-keyword-params
      add-user-to-context


### PR DESCRIPTION
CORE-7153

All services which use the `wrap-logging` middleware should be using the new `clean-context` middleware as well. The `clean-context` middleware should be the first in the chain of execution leading to the handler, with the intent of surrounding the handler and every other middleware in a `(with-logging-context {} ...)` macro.

I manually tested each respective service by running builds and placing MDC keys in the `GET /` route. Then, I'd make multiple calls and ensure that the key is never in the _request_ log entry.
