### PR TITLE
Use jeanblanchard/java:8 image instead of java:8 image as a base for discoenv/javabase. This image should be very substantially smaller.

### DIFF
--- a/docker/javabase.docker
+++ b/docker/javabase.docker
@@ -1,6 +1,8 @@
-FROM java:8
+FROM jeanblanchard/java:8
 
-RUN useradd -m -U -s /bin/bash -u 1337 iplant
+RUN mkdir -p /home/iplant
+RUN busybox adduser -s /bin/sh -u 1337 -D -h /home/iplant iplant
+
 USER iplant
 RUN mkdir -p /home/iplant/logs/
 WORKDIR /home/iplant


### PR DESCRIPTION
In local testing, this image resulted in a 262MB iplant-groups image vs. the current discoenv/iplant-groups:latest, which is 906.2MB. I've verified that at least iplant-groups runs as expected within this new container, but this is a PR against 2.3 to ensure this'll get good testing.
